### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ usage: signal-cli [-h] [-v] [--config CONFIG] [-u USERNAME | --dbus | --dbus-sys
 
           signal-cli -u USERNAME trust -a NUMBER
 
+* Set configuration directory
+
+          signal-cli -config=/home/other_user/.config/signal
+
+        This is particularily useful in the case, when you would like to run the signal-cli tool as a different user as the one, that was used to register the account. You should make sure, that the caller can list and read the given directory.
+        
 ## DBus service
 
 signal-cli can run in daemon mode and provides an experimental dbus interface.

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ usage: signal-cli [-h] [-v] [--config CONFIG] [-u USERNAME | --dbus | --dbus-sys
 
 * Set configuration directory
 
-          signal-cli -config=/home/other_user/.config/signal
+          signal-cli --config=/home/other_user/.config/signal
 
-        This is particularily useful in the case, when you would like to run the signal-cli tool as a different user as the one, that was used to register the account. You should make sure, that the caller can list and read the given directory.
+        This is particularily useful in the case, when you would like to run the signal-cli tool as a different user as the one, that was used to register the account. You should make sure, that the caller has full read/write access to the given directory.
         
 ## DBus service
 


### PR DESCRIPTION
I use a server monitoring solution (Zabbix) and wanted to use signal-cli for notifications. The monitoring solutions can call external scripts in case of problems but obviously uses it's own user to do this. I read about --config in the source and thought, that other people would benefit from this information as well.