### PR TITLE
Clarify README around system bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ To run on the system bus you need to take some additional steps.
 It’s advisable to run signal-cli as a separate unix user, the following steps assume you created a user named *signal-cli*.
 These steps, executed as root, should work on all distributions using systemd.
 
+Mind the fact that signal.service executes the signal-cli with "--config /var/lib/signal-cli".
+If you registered with user signal-cli, remove the config option.
+
 ```bash
 cp data/org.asamk.Signal.conf /etc/dbus-1/system.d/
 cp data/org.asamk.Signal.service /usr/share/dbus-1/system-services/

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ systemctl enable signal.service
 systemctl reload dbus.service
 ```
 
-Then just execute the send command from above, the service will be autostarted by dbus the first time it is requested.
+Make sure to use "--dbus-system" with the send command, the service will be autostarted by dbus the first time it is requested.
 
 ## Storage
 


### PR DESCRIPTION
After having to questions/problems (#45, #46) with signal-cli around using it on the system bus, I thought I could clarify the README. So that anybody I'm hopeful the last person to raise these questions.