### PR TITLE
Add eclipse plugin to build.gradle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ build/
 *.swp
 *.iml
 local.properties
+.classpath
+.project
+.settings/
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'application'
+apply plugin: 'eclipse'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7


### PR DESCRIPTION
This allows easy generation of eclipse project files using `./gradlew
eclipse`

Exactly what it says on the tin. I like working with eclipse, and then this is really useful.