### PR TITLE
Allow retreving and updating group info and contact names via dbus

### DIFF
--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -23,6 +23,8 @@ public interface Signal extends DBusInterface {
 
     void setContactName(String number, String name);
 
+    String getGroupName(byte[] groupId);
+
     class MessageReceived extends DBusSignal {
         private long timestamp;
         private String sender;

--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -21,9 +21,11 @@ public interface Signal extends DBusInterface {
 
     String getContactName(String number);
 
+    String getGroupName(byte[] groupId);
+
     void setContactName(String number, String name);
 
-    String getGroupName(byte[] groupId);
+    void updateGroup(byte[] groupId, String name, List<String> members, String avatar) throws IOException, EncapsulatedExceptions, GroupNotFoundException, AttachmentInvalidException;
 
     class MessageReceived extends DBusSignal {
         private long timestamp;

--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -19,6 +19,10 @@ public interface Signal extends DBusInterface {
 
     void sendGroupMessage(String message, List<String> attachments, byte[] groupId) throws EncapsulatedExceptions, GroupNotFoundException, AttachmentInvalidException, IOException;
 
+    String getContactName(String number);
+
+    void setContactName(String number, String name);
+
     class MessageReceived extends DBusSignal {
         private long timestamp;
         private String sender;

--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -21,9 +21,11 @@ public interface Signal extends DBusInterface {
 
     String getContactName(String number);
 
+    void setContactName(String number, String name);
+
     String getGroupName(byte[] groupId);
 
-    void setContactName(String number, String name);
+    List<String> getGroupMembers(byte[] groupId);
 
     void updateGroup(byte[] groupId, String name, List<String> members, String avatar) throws IOException, EncapsulatedExceptions, GroupNotFoundException, AttachmentInvalidException;
 

--- a/src/main/java/org/asamk/signal/Manager.java
+++ b/src/main/java/org/asamk/signal/Manager.java
@@ -834,8 +834,7 @@ class Manager implements Signal {
         if (!avatar.isEmpty()) {
             optAvatar = avatar;
         }
-        System.err.println("sendUpdateGroupMessage(" + Base64.encodeBytes(groupId) + ", " + optName + ", " + optMembers + ", " + optAvatar + ");");
-        sendUpdateGroupMessage(groupId, optName, optMembers, null);
+        sendUpdateGroupMessage(groupId, optName, optMembers, optAvatar);
     }
 
     private void requestSyncGroups() throws IOException {

--- a/src/main/java/org/asamk/signal/Manager.java
+++ b/src/main/java/org/asamk/signal/Manager.java
@@ -822,19 +822,16 @@ class Manager implements Signal {
 
     @Override
     public void updateGroup(byte[] groupId, String name, List<String> members, String avatar) throws IOException, EncapsulatedExceptions, GroupNotFoundException, AttachmentInvalidException {
-        String optName = null;
-        Collection<String> optMembers = null;
-        String optAvatar = null;
-        if (!name.isEmpty()) {
-            optName = name;
+        if (name.isEmpty()) {
+            name = null;
         }
-        if (members.size() > 0) {
-            optMembers = members;
+        if (members.size() == 0) {
+            members = null;
         }
-        if (!avatar.isEmpty()) {
-            optAvatar = avatar;
+        if (avatar.isEmpty()) {
+            avatar = null;
         }
-        sendUpdateGroupMessage(groupId, optName, optMembers, optAvatar);
+        sendUpdateGroupMessage(groupId, name, members, avatar);
     }
 
     private void requestSyncGroups() throws IOException {

--- a/src/main/java/org/asamk/signal/Manager.java
+++ b/src/main/java/org/asamk/signal/Manager.java
@@ -802,12 +802,22 @@ class Manager implements Signal {
 
     @Override
     public String getGroupName(byte[] groupId) {
-        return getGroup(groupId).name;
+        GroupInfo group = getGroup(groupId);
+        if (group == null) {
+            return "";
+        } else {
+            return group.name;
+        }
     }
 
     @Override
     public List<String> getGroupMembers(byte[] groupId) {
-        return new ArrayList<String>(getGroup(groupId).members);
+        GroupInfo group = getGroup(groupId);
+        if (group == null) {
+            return new ArrayList<String>();
+        } else {
+            return new ArrayList<String>(group.members);
+        }
     }
 
     @Override

--- a/src/main/java/org/asamk/signal/Manager.java
+++ b/src/main/java/org/asamk/signal/Manager.java
@@ -775,6 +775,30 @@ class Manager implements Signal {
         sendMessage(messageBuilder, recipients);
     }
 
+    @Override
+    public String getContactName(String number) {
+        ContactInfo contact = contactStore.getContact(number);
+        if(contact == null) {
+            return number;
+        } else {
+            return contact.name;
+        }
+    }
+
+    @Override
+    public void setContactName(String number, String name) {
+        ContactInfo contact = contactStore.getContact(number);
+        if(contact == null) {
+            contact = new ContactInfo();
+            contact.number = number;
+            System.out.println("Add contact " + number + " named " + name);
+        } else {
+            System.out.println("Updating contact " + number + " name " + contact.name + " -> " + name);
+        }
+        contact.name = name;
+        contactStore.updateContact(contact);
+    }
+
     private void requestSyncGroups() throws IOException {
         SignalServiceProtos.SyncMessage.Request r = SignalServiceProtos.SyncMessage.Request.newBuilder().setType(SignalServiceProtos.SyncMessage.Request.Type.GROUPS).build();
         SignalServiceSyncMessage message = SignalServiceSyncMessage.forRequest(new RequestMessage(r));

--- a/src/main/java/org/asamk/signal/Manager.java
+++ b/src/main/java/org/asamk/signal/Manager.java
@@ -802,6 +802,7 @@ class Manager implements Signal {
         }
         contact.name = name;
         contactStore.updateContact(contact);
+        save();
     }
 
     private void requestSyncGroups() throws IOException {

--- a/src/main/java/org/asamk/signal/Manager.java
+++ b/src/main/java/org/asamk/signal/Manager.java
@@ -778,7 +778,7 @@ class Manager implements Signal {
     @Override
     public String getContactName(String number) {
         ContactInfo contact = contactStore.getContact(number);
-        if(contact == null) {
+        if (contact == null) {
             return number;
         } else {
             return contact.name;
@@ -788,7 +788,7 @@ class Manager implements Signal {
     @Override
     public void setContactName(String number, String name) {
         ContactInfo contact = contactStore.getContact(number);
-        if(contact == null) {
+        if (contact == null) {
             contact = new ContactInfo();
             contact.number = number;
             System.out.println("Add contact " + number + " named " + name);
@@ -815,13 +815,13 @@ class Manager implements Signal {
         String optName = null;
         Collection<String> optMembers = null;
         String optAvatar = null;
-        if(!name.isEmpty()) {
+        if (!name.isEmpty()) {
             optName = name;
         }
-        if(members.size() > 0) {
+        if (members.size() > 0) {
             optMembers = members;
         }
-        if(!avatar.isEmpty()) {
+        if (!avatar.isEmpty()) {
             optAvatar = avatar;
         }
         System.err.println("sendUpdateGroupMessage(" + Base64.encodeBytes(groupId) + ", " + optName + ", " + optMembers + ", " + optAvatar + ");");

--- a/src/main/java/org/asamk/signal/Manager.java
+++ b/src/main/java/org/asamk/signal/Manager.java
@@ -779,7 +779,7 @@ class Manager implements Signal {
     public String getContactName(String number) {
         ContactInfo contact = contactStore.getContact(number);
         if (contact == null) {
-            return number;
+            return "";
         } else {
             return contact.name;
         }

--- a/src/main/java/org/asamk/signal/Manager.java
+++ b/src/main/java/org/asamk/signal/Manager.java
@@ -786,6 +786,11 @@ class Manager implements Signal {
     }
 
     @Override
+    public String getGroupName(byte[] groupId) {
+        return getGroup(groupId).name;
+    }
+
+    @Override
     public void setContactName(String number, String name) {
         ContactInfo contact = contactStore.getContact(number);
         if(contact == null) {

--- a/src/main/java/org/asamk/signal/Manager.java
+++ b/src/main/java/org/asamk/signal/Manager.java
@@ -786,11 +786,6 @@ class Manager implements Signal {
     }
 
     @Override
-    public String getGroupName(byte[] groupId) {
-        return getGroup(groupId).name;
-    }
-
-    @Override
     public void setContactName(String number, String name) {
         ContactInfo contact = contactStore.getContact(number);
         if(contact == null) {
@@ -803,6 +798,16 @@ class Manager implements Signal {
         contact.name = name;
         contactStore.updateContact(contact);
         save();
+    }
+
+    @Override
+    public String getGroupName(byte[] groupId) {
+        return getGroup(groupId).name;
+    }
+
+    @Override
+    public List<String> getGroupMembers(byte[] groupId) {
+        return new ArrayList<String>(getGroup(groupId).members);
     }
 
     @Override

--- a/src/main/java/org/asamk/signal/Manager.java
+++ b/src/main/java/org/asamk/signal/Manager.java
@@ -805,6 +805,24 @@ class Manager implements Signal {
         save();
     }
 
+    @Override
+    public void updateGroup(byte[] groupId, String name, List<String> members, String avatar) throws IOException, EncapsulatedExceptions, GroupNotFoundException, AttachmentInvalidException {
+        String optName = null;
+        Collection<String> optMembers = null;
+        String optAvatar = null;
+        if(!name.isEmpty()) {
+            optName = name;
+        }
+        if(members.size() > 0) {
+            optMembers = members;
+        }
+        if(!avatar.isEmpty()) {
+            optAvatar = avatar;
+        }
+        System.err.println("sendUpdateGroupMessage(" + Base64.encodeBytes(groupId) + ", " + optName + ", " + optMembers + ", " + optAvatar + ");");
+        sendUpdateGroupMessage(groupId, optName, optMembers, null);
+    }
+
     private void requestSyncGroups() throws IOException {
         SignalServiceProtos.SyncMessage.Request r = SignalServiceProtos.SyncMessage.Request.newBuilder().setType(SignalServiceProtos.SyncMessage.Request.Type.GROUPS).build();
         SignalServiceSyncMessage message = SignalServiceSyncMessage.forRequest(new RequestMessage(r));


### PR DESCRIPTION
This PR enables contact names, group names and group member lists to be read and updated over dbus. Superseeding #61 which just allows reading.