### PR TITLE
Add getGroupIds() to DBUS interface

### DIFF
--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -23,6 +23,8 @@ public interface Signal extends DBusInterface {
 
     void setContactName(String number, String name);
 
+    List<byte[]> getGroupIds();
+
     String getGroupName(byte[] groupId);
 
     List<String> getGroupMembers(byte[] groupId);

--- a/src/main/java/org/asamk/signal/Manager.java
+++ b/src/main/java/org/asamk/signal/Manager.java
@@ -805,6 +805,16 @@ class Manager implements Signal {
     }
 
     @Override
+    public List<byte[]> getGroupIds() {
+        List<GroupInfo> groups = getGroups();
+        List<byte[]> ids = new ArrayList<byte[]>(groups.size());
+        for (GroupInfo group : groups) {
+          ids.add(group.groupId);
+        }
+        return ids;
+    }
+
+    @Override
     public String getGroupName(byte[] groupId) {
         GroupInfo group = getGroup(groupId);
         if (group == null) {


### PR DESCRIPTION
`getGroupIds()` returns a list of group ids (byte array)

This comes handy if you want to use `getGroup*()` methods but don't have the group id.