### PR TITLE
change SecureRandom Provider to best available (OS=`/dev/urandom`)

### DIFF
--- a/src/main/java/org/asamk/signal/util/Util.java
+++ b/src/main/java/org/asamk/signal/util/Util.java
@@ -21,7 +21,7 @@ public class Util {
 
     private static SecureRandom getSecureRandom() {
         try {
-            return SecureRandom.getInstance("SHA1PRNG");
+            return SecureRandom.getInstance("NativePRNG");
         } catch (NoSuchAlgorithmException e) {
             throw new AssertionError(e);
         }


### PR DESCRIPTION
Currently `src/main/java/org/asamk/signal/util/Util.java` uses the
 `SHA1PRNG` algorithm  by Sun/Oracle to get randomness for `nextBytes` etc.

[_their_ (Oracle/Sun) documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SecureRandomImp) states: 
> ** On Solaris, Linux, and OS X, if the entropy gathering device in
> java.security is set to file:/dev/urandom or file:/dev/random, then
> NativePRNG is preferred to SHA1PRNG. Otherwise, SHA1PRNG is preferred.


and:


> The following algorithms are available in the SUN provider:
> 
> [...]
> 
> SecureRandom
> 
> SHA1PRNG (Initial seeding is currently done via a combination of system attributes and the java.security entropy gathering device)
> NativePRNG (nextBytes() uses /dev/urandom, generateSeed() uses /dev/random)
> NativePRNGBlocking (nextBytes() and generateSeed() use /dev/random)
> NativePRNGNonBlocking (nextBytes() and generateSeed() use /dev/urandom)

Using `/dev/urandom` (non-blocking, reworked in new linux kernel
releases) also reflects the opinion of many leading cryptographers over
any other solution of PRNGs out there, there you can find two crypto- and
a Java-specific blog post to underline this/my statement and for reassurance:
1. https://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/
2. https://tersesystems.com/blog/2015/12/17/the-right-way-to-use-securerandom/
3. https://www.2uo.de/myths-about-urandom

Since we're not re-seeding a lot we're good using a blocking `/dev/random`
for seed generation (which thus also creates more secure seeds) and a faster, 
newly re-written implementation of `/dev/urandom` for (streaming) random bytes. 

I think this is the best choice we have available here.

I did  give a talk at SHA2017 on the subject matter, in case you're interested: 
https://www.youtube.com/watch?v=Yx4RroggBzI (including mentioned changes 
to Linux's CSPRNG design - though a lot of new improvements have since been
merged, especially since they're working on adding `Wireguard` to mainline).