### PR TITLE
Don't abort on empty recipient unless there was also no group specified.

### DIFF
--- a/src/main/java/org/asamk/signal/commands/SendCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendCommand.java
@@ -52,7 +52,7 @@ public class SendCommand implements DbusCommand {
             return 1;
         }
 
-        if (ns.getBoolean("endsession") && ns.getList("recipient") != null && ns.getList("recipient").size() > 0) {
+        if (ns.getBoolean("endsession")) {
             try {
                 signal.sendEndSessionMessage(ns.<String>getList("recipient"));
                 return 0;

--- a/src/main/java/org/asamk/signal/commands/SendCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendCommand.java
@@ -46,6 +46,12 @@ public class SendCommand implements DbusCommand {
             return 1;
         }
 
+        if ((ns.getList("recipient") == null || ns.getList("recipient").size() == 0) && (ns.getBoolean("endsession") || ns.getString("group") == null)) {
+            System.err.println("No recipients given");
+            System.err.println("Aborting sending.");
+            return 1;
+        }
+
         if (ns.getBoolean("endsession") && ns.getList("recipient") != null && ns.getList("recipient").size() > 0) {
             try {
                 signal.sendEndSessionMessage(ns.<String>getList("recipient"));
@@ -63,12 +69,6 @@ public class SendCommand implements DbusCommand {
                 handleDBusExecutionException(e);
                 return 1;
             }
-        }
-
-        if ((ns.getList("recipient") == null || ns.getList("recipient").size() == 0) && ns.getString("group") == null) {
-            System.err.println("No recipients given");
-            System.err.println("Aborting sending.");
-            return 1;
         }
 
         String messageText = ns.getString("message");

--- a/src/main/java/org/asamk/signal/commands/SendCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendCommand.java
@@ -46,13 +46,7 @@ public class SendCommand implements DbusCommand {
             return 1;
         }
 
-        if ((ns.getList("recipient") == null || ns.getList("recipient").size() == 0) && ns.getString("group") == null) {
-            System.err.println("No recipients given");
-            System.err.println("Aborting sending.");
-            return 1;
-        }
-
-        if (ns.getBoolean("endsession")) {
+        if (ns.getBoolean("endsession") && ns.getList("recipient") != null && ns.getList("recipient").size() > 0) {
             try {
                 signal.sendEndSessionMessage(ns.<String>getList("recipient"));
                 return 0;
@@ -69,6 +63,12 @@ public class SendCommand implements DbusCommand {
                 handleDBusExecutionException(e);
                 return 1;
             }
+        }
+
+        if ((ns.getList("recipient") == null || ns.getList("recipient").size() == 0) && ns.getString("group") == null) {
+            System.err.println("No recipients given");
+            System.err.println("Aborting sending.");
+            return 1;
         }
 
         String messageText = ns.getString("message");

--- a/src/main/java/org/asamk/signal/commands/SendCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendCommand.java
@@ -46,7 +46,7 @@ public class SendCommand implements DbusCommand {
             return 1;
         }
 
-        if (ns.getList("recipient") == null || ns.getList("recipient").size() == 0) {
+        if ((ns.getList("recipient") == null || ns.getList("recipient").size() == 0) && ns.getString("group") == null) {
             System.err.println("No recipients given");
             System.err.println("Aborting sending.");
             return 1;


### PR DESCRIPTION
This fixes https://github.com/AsamK/signal-cli/issues/175.

The current recipient check prevents sending messages to a group. I've added a condition to the if statement so that it will continue sending the message if a group has been specified.