### PR TITLE
Add parameter to specify busname

### DIFF
--- a/src/main/java/org/asamk/signal/Main.java
+++ b/src/main/java/org/asamk/signal/Main.java
@@ -167,6 +167,8 @@ public class Main {
                 .action(Arguments.version());
         parser.addArgument("--config")
                 .help("Set the path, where to store the config (Default: $XDG_DATA_HOME/signal-cli , $HOME/.local/share/signal-cli).");
+        parser.addArgument("-n", "--busname")
+                .help("Name of the DBus.");
 
         MutuallyExclusiveGroup mut = parser.addMutuallyExclusiveGroup();
         mut.addArgument("-u", "--username")

--- a/src/main/java/org/asamk/signal/commands/DaemonCommand.java
+++ b/src/main/java/org/asamk/signal/commands/DaemonCommand.java
@@ -41,6 +41,7 @@ public class DaemonCommand implements LocalCommand {
         try {
             try {
                 int busType;
+                String  busName;
                 if (ns.getBoolean("system")) {
                     busType = DBusConnection.SYSTEM;
                 } else {
@@ -48,7 +49,12 @@ public class DaemonCommand implements LocalCommand {
                 }
                 conn = DBusConnection.getConnection(busType);
                 conn.exportObject(SIGNAL_OBJECTPATH, m);
-                conn.requestBusName(SIGNAL_BUSNAME);
+		busName = ns.getString("busname");
+		if (busName == null) {
+		    conn.requestBusName(SIGNAL_BUSNAME);
+		} else {
+		    conn.requestBusName(busName);
+		}
             } catch (UnsatisfiedLinkError e) {
                 System.err.println("Missing native library dependency for dbus service: " + e.getMessage());
                 return 1;


### PR DESCRIPTION
This way multiple instances of signal-cli can run in daemon-mode in
parallel. This was not possible previously as they tried to create the
same DBus.

This is rather my own quick fix and I guess there exists a cleaner way.
(Maybe let the parser parse the busname directly to `SIGNAL_BUSNAME`.)