### PR TITLE
Configure dbus name via commandline parameter

### DIFF
--- a/data/org.asamk.Signal_NUMBER.conf
+++ b/data/org.asamk.Signal_NUMBER.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0"?> <!--*-nxml-*-->
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<busconfig>
+        <policy user="signal-cli">
+                <allow own="org.asamk.Signal_%number%"/>
+                <allow send_destination="org.asamk.Signal_%number%"/>
+                <allow receive_sender="org.asamk.Signal_%number%"/>
+        </policy>
+
+        <policy context="default">
+                <allow send_destination="org.asamk.Signal_%number%"/>
+                <allow receive_sender="org.asamk.Signal_%number%"/>
+        </policy>
+</busconfig>

--- a/data/signal-cli@.service
+++ b/data/signal-cli@.service
@@ -8,9 +8,9 @@ After=network-online.target
 [Service]
 Type=dbus
 Environment="SIGNAL_CLI_OPTS=-Xms2m"
-ExecStart=%dir%/bin/signal-cli -u %I --config /var/lib/signal-cli daemon --system
+ExecStart=%dir%/bin/signal-cli -u +%I --busname org.asamk.Signal_%I --config /var/lib/signal-cli daemon --system
 User=signal-cli
-BusName=org.asamk.Signal
+BusName=org.asamk.Signal_%I
 
 [Install]
 WantedBy=multi-user.target

--- a/src/main/java/org/asamk/signal/DbusConfig.java
+++ b/src/main/java/org/asamk/signal/DbusConfig.java
@@ -2,6 +2,25 @@ package org.asamk.signal;
 
 public class DbusConfig {
 
-    public static final String SIGNAL_BUSNAME = "org.asamk.Signal";
-    public static final String SIGNAL_OBJECTPATH = "/org/asamk/Signal";
+    public DbusConfig() {
+    }
+
+    public String signalBusName = "org.asamk.Signal";
+    public String signalObjectPath = "/org/asamk/Signal";
+
+    public void setName(String busName) {
+        DbusConfig.this.signalBusName = busName;
+    }
+
+    public String getName() {
+        return DbusConfig.this.signalBusName;
+    }
+
+    public void setObjectPath(String objectPath) {
+        DbusConfig.this.signalObjectPath = objectPath;
+    }
+
+    public String getObjectPath() {
+        return DbusConfig.this.signalObjectPath;
+    }
 }

--- a/src/main/java/org/asamk/signal/Main.java
+++ b/src/main/java/org/asamk/signal/Main.java
@@ -20,6 +20,7 @@ import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.*;
 import org.asamk.Signal;
+import org.asamk.signal.DbusConfig;
 import org.asamk.signal.commands.*;
 import org.asamk.signal.manager.BaseConfig;
 import org.asamk.signal.manager.Manager;
@@ -57,6 +58,9 @@ public class Main {
         Manager m;
         Signal ts;
         DBusConnection dBusConn = null;
+        DbusConfig dbc = new DbusConfig();
+        if (!isEmpty(ns.getString("busname")))
+            dbc.setName(ns.getString("busname"));
         try {
             if (ns.getBoolean("dbus") || ns.getBoolean("dbus_system")) {
                 try {
@@ -69,7 +73,7 @@ public class Main {
                     }
                     dBusConn = DBusConnection.getConnection(busType);
                     ts = dBusConn.getRemoteObject(
-                            DbusConfig.SIGNAL_BUSNAME, DbusConfig.SIGNAL_OBJECTPATH,
+                            dbc.getName(), dbc.getObjectPath(),
                             Signal.class);
                 } catch (UnsatisfiedLinkError e) {
                     System.err.println("Missing native library dependency for dbus service: " + e.getMessage());
@@ -168,6 +172,8 @@ public class Main {
                 .action(Arguments.version());
         parser.addArgument("--config")
                 .help("Set the path, where to store the config (Default: $XDG_DATA_HOME/signal-cli , $HOME/.local/share/signal-cli).");
+        parser.addArgument("--busname")
+                .help("Specify the dbus name, that will be used for communication (Default: org.asamk.Signal).");
 
         MutuallyExclusiveGroup mut = parser.addMutuallyExclusiveGroup();
         mut.addArgument("-u", "--username")


### PR DESCRIPTION
Same goal as [Add parameter to specify DBus name](https://github.com/AsamK/signal-cli/pull/187): configure dbus name via commandline parameter `--busname` to run multiple signal-cli daemons on different bus names in parallel.

The class [src/main/java/org/asamk/signal/DbusConfig.java](https://github.com/AsamK/signal-cli/compare/master...groupnet:feature/multipleDbus?expand=1#diff-06695f6173c02d6a507d9ec7fc94d69d) was adapted accordingly: the constant SIGNAL_BUSNAME was replaced by a variable and setter/getter functions. To keep the class uniform also the SIGNAL_OBJECTPATH was made variable but the _signalObjectPath_ was not exposed to the command line parameters.

Accidentally, I've also updated the Wiki's page (in the believe I was working on the fork), but removed the changes again. Anyway, you find the adaption here: [DBus service (c322d64)](https://github.com/AsamK/signal-cli/wiki/DBus-service/c322d64bc757a421cf68bd42e003f1f43fe776a4)

ToDo: adapt man page