### PR TITLE
Throw error on failed authorization

### DIFF
--- a/src/main/java/org/asamk/signal/manager/Manager.java
+++ b/src/main/java/org/asamk/signal/manager/Manager.java
@@ -137,6 +137,7 @@ public class Manager implements Signal {
             }
         } catch (AuthorizationFailedException e) {
             System.err.println("Authorization failed, was the number registered elsewhere?");
+            throw e;
         }
     }
 


### PR DESCRIPTION
 - to exit signal-cli in case the number was registered elsewhere
 - solves issue [signal-cli does not exit on authorization failure](https://github.com/AsamK/signal-cli/issues/211) #211