### PR TITLE
Update SignalAccount storage on unregister

### DIFF
--- a/src/main/java/org/asamk/signal/manager/Manager.java
+++ b/src/main/java/org/asamk/signal/manager/Manager.java
@@ -209,6 +209,9 @@ public class Manager implements Signal {
         // If this is the master device, other users can't send messages to this number anymore.
         // If this is a linked device, other users can still send messages, but this device doesn't receive them anymore.
         accountManager.setGcmId(Optional.<String>absent());
+
+        account.setRegistered(false);
+        account.save();
     }
 
     public String getDeviceLinkUri() throws TimeoutException, IOException {


### PR DESCRIPTION
 - save registered false state in the SignalAccount storage on unregister action
 - solves https://github.com/AsamK/signal-cli/issues/214