### PR TITLE
Added destination field of sync messages to JSON output

### DIFF
--- a/src/main/java/org/asamk/signal/JsonSyncMessage.java
+++ b/src/main/java/org/asamk/signal/JsonSyncMessage.java
@@ -2,18 +2,24 @@ package org.asamk.signal;
 
 import org.whispersystems.signalservice.api.messages.multidevice.ReadMessage;
 import org.whispersystems.signalservice.api.messages.multidevice.SignalServiceSyncMessage;
+import org.whispersystems.signalservice.api.messages.multidevice.SentTranscriptMessage;
 
 import java.util.List;
 
 class JsonSyncMessage {
 
     JsonDataMessage sentMessage;
+    String destination;
     List<String> blockedNumbers;
     List<ReadMessage> readMessages;
 
     JsonSyncMessage(SignalServiceSyncMessage syncMessage) {
         if (syncMessage.getSent().isPresent()) {
-            this.sentMessage = new JsonDataMessage(syncMessage.getSent().get().getMessage());
+            final SentTranscriptMessage sentTranscriptMessage = syncMessage.getSent().get();
+            if (sentTranscriptMessage.getDestination().isPresent()) {
+                this.destination = sentTranscriptMessage.getDestination().get();
+            }
+            this.sentMessage = new JsonDataMessage(sentTranscriptMessage.getMessage());
         }
         if (syncMessage.getBlockedList().isPresent()) {
             this.blockedNumbers = syncMessage.getBlockedList().get().getNumbers();


### PR DESCRIPTION
Because the JSON output to stdout is not as robust as the human-readable output, I added the destination field from SentTranscriptMessage to JsonSyncMessage. This allows programs that read from stdout to better differentiate between messages. 

In another pull request, I will also look into creating a JsonReceiptMessage in order to add information from SignalServiceReceiptMessage to JsonMessageEnvelope, similarly to how it's handled in ReceiveMessageHandler.