### PR TITLE
Added ReceiptMessage to JSON output

### DIFF
--- a/src/main/java/org/asamk/signal/JsonMessageEnvelope.java
+++ b/src/main/java/org/asamk/signal/JsonMessageEnvelope.java
@@ -14,6 +14,7 @@ class JsonMessageEnvelope {
     JsonDataMessage dataMessage;
     JsonSyncMessage syncMessage;
     JsonCallMessage callMessage;
+    JsonReceiptMessage receiptMessage;
 
     public JsonMessageEnvelope(SignalServiceEnvelope envelope, SignalServiceContent content) {
         SignalServiceAddress source = envelope.getSourceAddress();
@@ -31,6 +32,9 @@ class JsonMessageEnvelope {
             }
             if (content.getCallMessage().isPresent()) {
                 this.callMessage = new JsonCallMessage(content.getCallMessage().get());
+            }
+            if (content.getReceiptMessage().isPresent()) {
+                this.receiptMessage = new JsonReceiptMessage(content.getReceiptMessage().get());
             }
         }
     }

--- a/src/main/java/org/asamk/signal/JsonReceiptMessage.java
+++ b/src/main/java/org/asamk/signal/JsonReceiptMessage.java
@@ -1,0 +1,25 @@
+package org.asamk.signal;
+
+import org.whispersystems.signalservice.api.messages.SignalServiceReceiptMessage;
+
+import java.util.List;
+
+class JsonReceiptMessage {
+
+    long when;
+    boolean isDelivery;
+    boolean isRead;
+    List<Long> timestamps;
+
+    JsonReceiptMessage(SignalServiceReceiptMessage receiptMessage) {
+
+        this.when = receiptMessage.getWhen();
+        if (receiptMessage.isDeliveryReceipt()) {
+            this.isDelivery = true;
+        }
+        if (receiptMessage.isReadReceipt()) {
+            this.isRead = true;
+        }
+        this.timestamps = receiptMessage.getTimestamps();
+    }
+}


### PR DESCRIPTION
Because the JSON output to stdout is not as robust as the human-readable output, I created a JsonReceiptMessage in order to add information from SignalServiceReceiptMessage to JsonMessageEnvelope, similarly to how it's handled in ReceiveMessageHandler. This allows programs that read from stdout to better differentiate between messages.