### PR TITLE
Add commands to update profile name and avatar

### DIFF
--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -208,6 +208,19 @@ number::
 	Specify the safety number or fingerprint of the key, only use this option if you have verified
 	the fingerprint.
 
+setProfileName
+--------------
+Update the name visible by message recipients for the current users.
+
+name::
+	New name visible by message recipients.
+
+setProfileAvatar
+----------------
+Update the avatar visible by message recipients for the current users.
+
+avatar::
+	Path to the new avatar visible by message recipients.
 
 daemon
 ~~~~~~

--- a/src/main/java/org/asamk/signal/commands/Commands.java
+++ b/src/main/java/org/asamk/signal/commands/Commands.java
@@ -20,6 +20,8 @@ public class Commands {
         addCommand("removeDevice", new RemoveDeviceCommand());
         addCommand("removePin", new RemovePinCommand());
         addCommand("send", new SendCommand());
+        addCommand("setProfileAvatar", new SetProfileAvatarCommand());
+        addCommand("setProfileName", new SetProfileNameCommand());
         addCommand("setPin", new SetPinCommand());
         addCommand("trust", new TrustCommand());
         addCommand("unregister", new UnregisterCommand());

--- a/src/main/java/org/asamk/signal/commands/SetProfileAvatarCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SetProfileAvatarCommand.java
@@ -1,0 +1,41 @@
+package org.asamk.signal.commands;
+
+import java.io.IOException;
+import java.io.File;
+
+import net.sourceforge.argparse4j.impl.Arguments;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.asamk.signal.manager.Manager;
+
+public class SetProfileAvatarCommand implements LocalCommand {
+
+    @Override
+    public void attachToSubparser(final Subparser subparser) {
+        subparser.addArgument("avatar")
+                .help("Path to new profile avatar");
+        subparser.help("Set the avatar for this profile");
+    }
+
+    @Override
+    public int handleCommand(final Namespace ns, final Manager m) {
+        if (!m.isRegistered()) {
+            System.err.println("User is not registered.");
+            return 1;
+        }
+
+        String avatarPath = ns.getString("avatar");
+	File avatarFile = new File(avatarPath);
+
+        try {
+            m.setProfileAvatar(avatarFile);
+	} catch (IOException e) {
+            System.err.println("UpdateAccount error: " + e.getMessage());
+            return 3;
+        }
+
+
+        return 0;
+    }
+
+}

--- a/src/main/java/org/asamk/signal/commands/SetProfileNameCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SetProfileNameCommand.java
@@ -1,0 +1,38 @@
+package org.asamk.signal.commands;
+
+import java.io.IOException;
+
+import net.sourceforge.argparse4j.impl.Arguments;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.asamk.signal.manager.Manager;
+
+public class SetProfileNameCommand implements LocalCommand {
+
+    @Override
+    public void attachToSubparser(final Subparser subparser) {
+        subparser.addArgument("name")
+                .help("New profile name");
+        subparser.help("Set a new name for this profile");
+    }
+
+    @Override
+    public int handleCommand(final Namespace ns, final Manager m) {
+        if (!m.isRegistered()) {
+            System.err.println("User is not registered.");
+            return 1;
+        }
+
+        String name = ns.getString("name");
+
+        try {
+            m.setProfileName(name);
+	} catch (IOException e) {
+            System.err.println("UpdateAccount error: " + e.getMessage());
+            return 3;
+        }
+
+        return 0;
+    }
+
+}

--- a/src/main/java/org/asamk/signal/manager/Manager.java
+++ b/src/main/java/org/asamk/signal/manager/Manager.java
@@ -54,6 +54,7 @@ import org.whispersystems.signalservice.api.push.exceptions.NetworkFailureExcept
 import org.whispersystems.signalservice.api.push.exceptions.UnregisteredUserException;
 import org.whispersystems.signalservice.api.util.InvalidNumberException;
 import org.whispersystems.signalservice.api.util.SleepTimer;
+import org.whispersystems.signalservice.api.util.StreamDetails;
 import org.whispersystems.signalservice.api.util.UptimeSleepTimer;
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos;
 import org.whispersystems.signalservice.internal.push.UnsupportedDataMessageException;
@@ -202,6 +203,14 @@ public class Manager implements Signal {
 
     public void updateAccountAttributes() throws IOException {
         accountManager.setAccountAttributes(account.getSignalingKey(), account.getSignalProtocolStore().getLocalRegistrationId(), true, account.getRegistrationLockPin(), getSelfUnidentifiedAccessKey(), false);
+    }
+
+    public void setProfileName(String name) throws IOException {
+        accountManager.setProfileName(account.getProfileKey(), name);
+    }
+
+    public void setProfileAvatar(File avatar) throws IOException {
+        accountManager.setProfileAvatar(account.getProfileKey(), Utils.createStreamDetailsFromFile(avatar));
     }
 
     public void unregister() throws IOException {

--- a/src/main/java/org/asamk/signal/manager/Utils.java
+++ b/src/main/java/org/asamk/signal/manager/Utils.java
@@ -15,6 +15,7 @@ import org.whispersystems.signalservice.api.messages.SignalServiceEnvelope;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 import org.whispersystems.signalservice.api.util.InvalidNumberException;
 import org.whispersystems.signalservice.api.util.PhoneNumberFormatter;
+import org.whispersystems.signalservice.api.util.StreamDetails;
 import org.whispersystems.signalservice.internal.util.Base64;
 
 import java.io.*;
@@ -54,6 +55,16 @@ class Utils {
         Optional<byte[]> preview = Optional.absent();
         Optional<String> caption = Optional.absent();
         return new SignalServiceAttachmentStream(attachmentStream, mime, attachmentSize, Optional.of(attachmentFile.getName()), false, preview, 0, 0, caption, null);
+    }
+
+    static StreamDetails createStreamDetailsFromFile(File file) throws IOException {
+        InputStream stream = new FileInputStream(file);
+        final long size = file.length();
+        String mime = Files.probeContentType(file.toPath());
+        if (mime == null) {
+            mime = "application/octet-stream";
+        }
+	return new StreamDetails(stream, mime, size);
     }
 
     static CertificateValidator getCertificateValidator() {


### PR DESCRIPTION
These changes add two new commands: `setProfileName` and `setProfileAvatar` which allow to update the name and avatar visible by other users for the current profiles.

Maybe it would be better to have a single command `updateProfile` but it felt more straightforward that way for the quick hacking session I allowed myself to solve this.

Implements #174 and address part of #98.