### PR TITLE
Add commands to update contact names on Signal servers

### DIFF
--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -208,6 +208,19 @@ number::
 	Specify the safety number or fingerprint of the key, only use this option if you have verified
 	the fingerprint.
 
+setContactName
+--------------
+Update name associated to a number on our contact list. This change is only local but can be synchronized to other devices by using `sendContacts` (see below).
+
+number::
+	Specify the contact phone number.
+
+name::
+	Specify the new name for this contact.
+
+sendContacts
+------------
+Update contact list on Signal servers.
 
 daemon
 ~~~~~~

--- a/src/main/java/org/asamk/signal/commands/Commands.java
+++ b/src/main/java/org/asamk/signal/commands/Commands.java
@@ -20,6 +20,8 @@ public class Commands {
         addCommand("removeDevice", new RemoveDeviceCommand());
         addCommand("removePin", new RemovePinCommand());
         addCommand("send", new SendCommand());
+        addCommand("sendContacts", new SendContactsCommand());
+        addCommand("setContactName", new SetContactNameCommand());
         addCommand("setPin", new SetPinCommand());
         addCommand("trust", new TrustCommand());
         addCommand("unregister", new UnregisterCommand());

--- a/src/main/java/org/asamk/signal/commands/SendContactsCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendContactsCommand.java
@@ -1,0 +1,31 @@
+package org.asamk.signal.commands;
+
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.asamk.signal.manager.Manager;
+import org.whispersystems.signalservice.api.crypto.UntrustedIdentityException;
+
+import java.io.IOException;
+
+public class SendContactsCommand implements LocalCommand {
+
+    @Override
+    public void attachToSubparser(final Subparser subparser) {
+        subparser.help("Send contacts to the signal server.");
+    }
+
+    @Override
+    public int handleCommand(final Namespace ns, final Manager m) {
+        if (!m.isRegistered()) {
+            System.err.println("User is not registered.");
+            return 1;
+        }
+        try {
+            m.sendContacts();
+            return 0;
+        } catch (IOException | UntrustedIdentityException e) {
+            System.err.println("SendContacts error: " + e.getMessage());
+            return 3;
+        }
+    }
+}

--- a/src/main/java/org/asamk/signal/commands/SetContactNameCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SetContactNameCommand.java
@@ -1,0 +1,34 @@
+package org.asamk.signal.commands;
+
+import net.sourceforge.argparse4j.impl.Arguments;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.asamk.signal.manager.Manager;
+
+public class SetContactNameCommand implements LocalCommand {
+
+    @Override
+    public void attachToSubparser(final Subparser subparser) {
+        subparser.addArgument("number")
+                .help("Contact number");
+        subparser.addArgument("name")
+                .help("New contact name");
+        subparser.help("Set the name of a given contact");
+    }
+
+    @Override
+    public int handleCommand(final Namespace ns, final Manager m) {
+        if (!m.isRegistered()) {
+            System.err.println("User is not registered.");
+            return 1;
+        }
+
+        String number = ns.getString("number");
+        String name = ns.getString("name");
+
+        m.setContactName(number, name);
+
+        return 0;
+    }
+
+}

--- a/src/main/java/org/asamk/signal/manager/Manager.java
+++ b/src/main/java/org/asamk/signal/manager/Manager.java
@@ -1347,7 +1347,7 @@ public class Manager implements Signal {
         }
     }
 
-    private void sendContacts() throws IOException, UntrustedIdentityException {
+    public void sendContacts() throws IOException, UntrustedIdentityException {
         File contactsFile = IOUtils.createTempFile();
 
         try {


### PR DESCRIPTION
As Signal Desktop does not allow its users to update the contact names, it would be nice to be able to update contact names from signal-cli when the latter is the master device.

The command `setContactName` allow to set the name for the given contact in the local store. `sendContacts` can then be used to push the updated contact list on Signal servers.

Address #111.