### PR TITLE
Use https for checkLibVersions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ task checkLibVersions {
                         def group = dependency.group
                         def path = group.replace('.', '/')
                         def name = dependency.name
-                        def url = "http://repo1.maven.org/maven2/$path/$name/maven-metadata.xml"
+                        def url = "https://repo1.maven.org/maven2/$path/$name/maven-metadata.xml"
                         try {
                             def metadata = new XmlSlurper().parseText(url.toURL().text)
                             def versions = metadata.versioning.versions.version.collect { it.text() }


### PR DESCRIPTION
As far as I can tell this is only a helper task called manually during development and only prints text, so the risk seems quite low, yet I think this should be updated to https.