### PR TITLE
Add basic sealed sender support

### DIFF
--- a/src/main/java/org/asamk/signal/JsonMessageEnvelope.java
+++ b/src/main/java/org/asamk/signal/JsonMessageEnvelope.java
@@ -19,6 +19,9 @@ class JsonMessageEnvelope {
     public JsonMessageEnvelope(SignalServiceEnvelope envelope, SignalServiceContent content) {
         SignalServiceAddress source = envelope.getSourceAddress();
         this.source = source.getNumber();
+        if (this.source.equals("")) {
+            this.source = content.getSender();
+        }
         this.sourceDevice = envelope.getSourceDevice();
         this.relay = source.getRelay().isPresent() ? source.getRelay().get() : null;
         this.timestamp = envelope.getTimestamp();

--- a/src/main/java/org/asamk/signal/ReceiveMessageHandler.java
+++ b/src/main/java/org/asamk/signal/ReceiveMessageHandler.java
@@ -43,8 +43,12 @@ public class ReceiveMessageHandler implements Manager.ReceiveMessageHandler {
     @Override
     public void handleMessage(SignalServiceEnvelope envelope, SignalServiceContent content, Throwable exception) {
         SignalServiceAddress source = envelope.getSourceAddress();
-        ContactInfo sourceContact = m.getContact(source.getNumber());
-        System.out.println(String.format("Envelope from: %s (device: %d)", (sourceContact == null ? "" : "“" + sourceContact.name + "” ") + source.getNumber(), envelope.getSourceDevice()));
+        String sender = source.getNumber();
+        if (sender.equals("")) {
+            sender = content.getSender();
+        }
+        ContactInfo sourceContact = m.getContact(sender);
+        System.out.println(String.format("Envelope from: %s (device: %d)", (sourceContact == null ? "" : "“" + sourceContact.name + "” ") + sender, envelope.getSourceDevice()));
         if (source.getRelay().isPresent()) {
             System.out.println("Relayed by: " + source.getRelay().get());
         }


### PR DESCRIPTION
This adds basic support to access the sender from messages sent by clients using sealed senders.

I'm still testing for the sender on the envelope first since this was necessary for some messages. I assume this is because signal-cli isn't sending with sealed-senders yet.

Related to #239 and #231.