### PR TITLE
[RFC] Handle sealed sender on receipt of data messages

### DIFF
--- a/src/main/java/org/asamk/signal/manager/Manager.java
+++ b/src/main/java/org/asamk/signal/manager/Manager.java
@@ -1151,18 +1151,27 @@ public class Manager implements Signal {
         }
     }
 
+    private static String senderForMessage(SignalServiceEnvelope envelope, SignalServiceContent content) {
+        String envelopeSource = envelope.getSource();
+        if (envelopeSource.isEmpty()) {
+            return content.getSender();
+        } else {
+            return envelopeSource;
+        }
+    }
+
     private void handleMessage(SignalServiceEnvelope envelope, SignalServiceContent content, boolean ignoreAttachments) {
         if (content != null) {
             if (content.getDataMessage().isPresent()) {
                 SignalServiceDataMessage message = content.getDataMessage().get();
-                handleSignalServiceDataMessage(message, false, envelope.getSource(), username, ignoreAttachments);
+                handleSignalServiceDataMessage(message, false, senderForMessage(envelope, content), username, ignoreAttachments);
             }
             if (content.getSyncMessage().isPresent()) {
                 account.setMultiDevice(true);
                 SignalServiceSyncMessage syncMessage = content.getSyncMessage().get();
                 if (syncMessage.getSent().isPresent()) {
                     SignalServiceDataMessage message = syncMessage.getSent().get().getMessage();
-                    handleSignalServiceDataMessage(message, true, envelope.getSource(), syncMessage.getSent().get().getDestination().get(), ignoreAttachments);
+                    handleSignalServiceDataMessage(message, true, senderForMessage(envelope, content), syncMessage.getSent().get().getDestination().get(), ignoreAttachments);
                 }
                 if (syncMessage.getRequest().isPresent()) {
                     RequestMessage rm = syncMessage.getRequest().get();


### PR DESCRIPTION
Since sealed sender became a thing, signal-cli fails to properly track the state of non-group threads as the envelope sender is always empty, so all thread state updates for such messages go to a thread with the id `""`.

This first shot at this is a quick hack that addresses the problem for regular messages. It doesn't yet address sync messages or other places that use the envelope sender.

Advice on style/how to structure this for real would be welcome.