### PR TITLE
Add support for uploading stickers.

### DIFF
--- a/src/main/java/org/asamk/signal/JsonStickerPack.java
+++ b/src/main/java/org/asamk/signal/JsonStickerPack.java
@@ -1,0 +1,27 @@
+package org.asamk.signal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class JsonStickerPack {
+    @JsonProperty
+    public String title;
+
+    @JsonProperty
+    public String author;
+
+    @JsonProperty
+    public JsonSticker cover;
+
+    @JsonProperty
+    public List<JsonSticker> stickers;
+
+    public static class JsonSticker {
+       @JsonProperty
+       public String emoji;
+
+       @JsonProperty
+       public String file;
+    }
+}

--- a/src/main/java/org/asamk/signal/StickerPackInvalidException.java
+++ b/src/main/java/org/asamk/signal/StickerPackInvalidException.java
@@ -1,0 +1,7 @@
+package org.asamk.signal;
+
+public class StickerPackInvalidException extends Exception {
+    public StickerPackInvalidException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/asamk/signal/commands/Commands.java
+++ b/src/main/java/org/asamk/signal/commands/Commands.java
@@ -30,6 +30,7 @@ public class Commands {
         addCommand("updateGroup", new UpdateGroupCommand());
         addCommand("updateProfile", new UpdateProfileCommand());
         addCommand("verify", new VerifyCommand());
+        addCommand("uploadStickerPack", new UploadStickerPackCommand());
     }
 
     public static Map<String, Command> getCommands() {

--- a/src/main/java/org/asamk/signal/commands/UploadStickerPackCommand.java
+++ b/src/main/java/org/asamk/signal/commands/UploadStickerPackCommand.java
@@ -1,0 +1,36 @@
+package org.asamk.signal.commands;
+
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.asamk.signal.StickerPackInvalidException;
+import org.asamk.signal.manager.Manager;
+import org.whispersystems.signalservice.internal.push.LockedException;
+
+import java.io.IOException;
+
+public class UploadStickerPackCommand implements LocalCommand {
+
+    @Override
+    public void attachToSubparser(final Subparser subparser) {
+        subparser.addArgument("path")
+                .help("The path of the manifest.json or a zip file containing the sticker pack you wish to upload.");
+    }
+
+    @Override
+    public int handleCommand(final Namespace ns, final Manager m) {
+        try {
+            String path = ns.getString("path");
+            String url = m.uploadStickerPack(path);
+            System.out.println("");
+            System.out.println("Upload complete! Sticker pack URL:");
+            System.out.println(url);
+            return 0;
+        } catch (IOException e) {
+            System.err.println("Upload error: " + e.getMessage());
+            return 3;
+        } catch (StickerPackInvalidException e) {
+            System.err.println("Invalid sticker pack: " + e.getMessage());
+            return 3;
+        }
+    }
+}

--- a/src/main/java/org/asamk/signal/util/IOUtils.java
+++ b/src/main/java/org/asamk/signal/util/IOUtils.java
@@ -1,9 +1,8 @@
 package org.asamk.signal.util;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
+import org.whispersystems.signalservice.internal.util.Util;
+
+import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -33,6 +32,12 @@ public class IOUtils {
             output.write(new String(buffer, 0, n, charset));
         }
         return output.toString();
+    }
+
+    public static byte[] readFully(InputStream in) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Util.copy(in, baos);
+        return baos.toByteArray();
     }
 
     public static void createPrivateDirectories(String directoryPath) throws IOException {


### PR DESCRIPTION
Depends on
- https://github.com/Turasa/libsignal-service-java/pull/21


This adds a command to allow users to upload sticker packs:

`signal-cli -u <user> uploadStickerPack <zipfile>`
or
`signal-cli -u <user> uploadStickerPack path/to/manifest.json`

The zip file is expected to contain the following:

```
|_ manifest.json
|_sticker0.webp
|_sticker1.webp
|_...
|_stickerN.webp
```

The `manifest.json` is expected to contain the following:

```
{
  "title": "<mandatory>",
  "author": "<mandatory>",
  // Optional
  "cover": {
    "file": "<name of webp file, mandatory>",
    "emoji": "<optional>"
  },
  // Mandatory
  "stickers": [
    {
      "file": "<name of webp file, mandatory>",
      "emoji": "<optional>"
    }
    ...
  ]
  }
}
```

I have no issue writing a wiki entry.