### PR TITLE
Use correct sticker pack key length of 32.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.turasa:signal-service-java:2.15.3_unofficial_5'
+    compile 'com.github.turasa:signal-service-java:2.15.3_unofficial_6'
     compile 'org.bouncycastle:bcprov-jdk15on:1.64'
     compile 'net.sourceforge.argparse4j:argparse4j:0.8.1'
     compile 'org.freedesktop.dbus:dbus-java:2.7.0'

--- a/src/main/java/org/asamk/signal/manager/KeyUtils.java
+++ b/src/main/java/org/asamk/signal/manager/KeyUtils.java
@@ -35,7 +35,7 @@ class KeyUtils {
     }
 
     static byte[] createStickerUploadKey() {
-        return getSecretBytes(64);
+        return getSecretBytes(32);
     }
 
     private static String getSecret(int size) {


### PR DESCRIPTION
(Depends on https://github.com/Turasa/libsignal-service-java/pull/23)

Pack keys should be 32 bytes which are then expanded to 64 via HKDF.

See Signal Desktop's upload process:
https://github.com/signalapp/Signal-Desktop/blob/87d6a55ce87a3f09e34da1dbc9e69f400ac7e32d/sticker-creator/preload.js#L93

Using a 64-byte key directly is technically valid, but it results in a URL that is much longer than necessary (since the pack key is hex-encoded and put in the URL as a query param).