### PR TITLE
Remove references to the native unix-java library

### DIFF
--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -313,8 +313,6 @@ The path of the manifest.json or a zip file containing the sticker pack you wish
 === daemon
 
 signal-cli can run in daemon mode and provides an experimental dbus interface.
-For dbus support you need jni/unix-java.so installed on your system (Debian:
-libunixsocket-java ArchLinux: libmatthew-unix-java (AUR)).
 
 *--system*::
 Use DBus system bus instead of user bus.


### PR DESCRIPTION
Since version 0.6.8 signal-cli uses hypfvieh dbus-java, so installing the packages libunixsocket-java (Debian), libmatthew-java (Fedora) or libmatthew-unix-java (ArchLinux) is not necessary.