### PR TITLE
add further clarification to addDevice docs

### DIFF
--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -103,7 +103,7 @@ Link another device to this device.
 Only works, if this is the master device.
 
 *--uri* URI::
-Specify the uri contained in the QR code shown by the new device.
+Specify the uri contained in the QR code shown by the new device. You will need the full uri enclosed in quotation marks, such as "tsdevice:/?uuid=....."
 
 === listDevices
 


### PR DESCRIPTION
I added a short note mentioning to add quotation marks around the full URI, otherwise the user receives "Invalid device URI" errors from Java.