### PR TITLE
Added JSON output to listGroups and allowed json to be activated with -j

### DIFF
--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -44,6 +44,9 @@ Make request via user dbus.
 *--dbus-system*::
 Make request via system dbus.
 
+*-o* OUTPUT-MODE, *--output* OUTPUT-MODE::
+Specify if you want commands to output in either "plain-text" mode or in "json". Defaults to "plain-text"
+
 == Commands
 
 === register
@@ -126,12 +129,10 @@ Use listDevices to see the deviceIds.
 
 === getUserStatus
 
-Uses a list of phone numbers to determine the statuses of those users. Shows if they are registered on the Signal Servers or not.
+Uses a list of phone numbers to determine the statuses of those users. Shows if they are registered on the Signal Servers or not. In json mode this is outputted as a list of objects.
 
 [NUMBER [NUMBER ...]]::
 One or more numbers to check.
-*--j*, *--json*::
-Output the statuses as an array of json objects.
 
 === send
 
@@ -177,15 +178,13 @@ Remove a reaction.
 === receive
 
 Query the server for new messages.
-New messages are printed on standardoutput and attachments are downloaded to the config directory.
+New messages are printed on standard output and attachments are downloaded to the config directory. In json mode this is outputted as one json object per line.
 
 *-t* TIMEOUT, *--timeout* TIMEOUT::
 Number of seconds to wait for new messages (negative values disable timeout).
 Default is 5 seconds.
 *--ignore-attachments*::
 Don’t download attachments of received messages.
-*--j*, *--json*::
-Output received messages in json format, one object per line.
 
 === joinGroup
 
@@ -222,13 +221,10 @@ Specify the recipient group ID in base64 encoding.
 
 === listGroups
 
-Show a list of known groups and related information.
+Show a list of known groups and related information. In json mode this is outputted as an list of objects and is always in detailed mode.
 
 *-d*, *--detailed*::
 Include the list of members of each group and the group invite link.
-
-*--j*, *--json*::
-Output group information as a list of json objects.
 
 === listIdentities
 

--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -130,7 +130,7 @@ Uses a list of phone numbers to determine the statuses of those users. Shows if 
 
 [NUMBER [NUMBER ...]]::
 One or more numbers to check.
-*--json*::
+*--j*, *--json*::
 Output the statuses as an array of json objects.
 
 === send
@@ -184,7 +184,7 @@ Number of seconds to wait for new messages (negative values disable timeout).
 Default is 5 seconds.
 *--ignore-attachments*::
 Don’t download attachments of received messages.
-*--json*::
+*--j*, *--json*::
 Output received messages in json format, one object per line.
 
 === joinGroup
@@ -222,10 +222,13 @@ Specify the recipient group ID in base64 encoding.
 
 === listGroups
 
-Show a list of known groups.
+Show a list of known groups and related information.
 
 *-d*, *--detailed*::
-Include the list of members of each group.
+Include the list of members of each group and the group invite link.
+
+*--j*, *--json*::
+Output group information as a list of json objects.
 
 === listIdentities
 

--- a/src/main/java/org/asamk/signal/Main.java
+++ b/src/main/java/org/asamk/signal/Main.java
@@ -283,6 +283,9 @@ public class Main {
         mut.addArgument("--dbus").help("Make request via user dbus.").action(Arguments.storeTrue());
         mut.addArgument("--dbus-system").help("Make request via system dbus.").action(Arguments.storeTrue());
 
+        parser.addArgument("-o", "--output").help("Choose to output in plain text or JSON")
+                .choices("plain-text", "json").setDefault("plain-text");
+
         Subparsers subparsers = parser.addSubparsers()
                 .title("subcommands")
                 .dest("command")

--- a/src/main/java/org/asamk/signal/commands/GetUserStatusCommand.java
+++ b/src/main/java/org/asamk/signal/commands/GetUserStatusCommand.java
@@ -8,6 +8,8 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
 import org.asamk.signal.manager.Manager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -16,6 +18,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class GetUserStatusCommand implements LocalCommand {
+
+    // TODO delete later when "json" variable is removed
+    final static Logger logger = LoggerFactory.getLogger(GetUserStatusCommand.class);
 
     @Override
     public void attachToSubparser(final Subparser subparser) {
@@ -32,6 +37,13 @@ public class GetUserStatusCommand implements LocalCommand {
         ObjectMapper jsonProcessor = new ObjectMapper();
         jsonProcessor.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
 
+        boolean inJson = ns.getString("output").equals("json");
+
+        // TODO delete later when "json" variable is removed
+        if (ns.getBoolean("json")) {
+            logger.warn("\"--json\" option has been deprecated, please use \"output\" instead.");
+        }
+
         // Get a map of registration statuses
         Map<String, Boolean> registered;
         try {
@@ -39,12 +51,6 @@ public class GetUserStatusCommand implements LocalCommand {
         } catch (IOException e) {
             System.err.println("Unable to check if users are registered");
             return 1;
-        }
-
-        boolean inJson = ns.getString("output").equals("json");
-        if (ns.getBoolean("json")) {
-            inJson = true;
-            System.out.println("WARNING: This parameter is now deprecated! Please use the \"output\" parameter instead.");
         }
 
         // Output

--- a/src/main/java/org/asamk/signal/commands/GetUserStatusCommand.java
+++ b/src/main/java/org/asamk/signal/commands/GetUserStatusCommand.java
@@ -21,6 +21,9 @@ public class GetUserStatusCommand implements LocalCommand {
     public void attachToSubparser(final Subparser subparser) {
         subparser.addArgument("number").help("Phone number").nargs("+");
         subparser.help("Check if the specified phone number/s have been registered");
+        subparser.addArgument("--json")
+                .help("WARNING: This parameter is now deprecated! Please use the \"output\" option instead.\n\nOutput received messages in json format, one json object per line.")
+                .action(Arguments.storeTrue());
     }
 
     @Override
@@ -38,8 +41,14 @@ public class GetUserStatusCommand implements LocalCommand {
             return 1;
         }
 
+        boolean inJson = ns.getString("output").equals("json");
+        if (ns.getBoolean("json")) {
+            inJson = true;
+            System.out.println("WARNING: This parameter is now deprecated! Please use the \"output\" parameter instead.");
+        }
+
         // Output
-        if (ns.getString("output").equals("json")) {
+        if (inJson) {
             List<JsonIsRegistered> objects = registered.entrySet()
                     .stream()
                     .map(entry -> new JsonIsRegistered(entry.getKey(), entry.getValue()))

--- a/src/main/java/org/asamk/signal/commands/GetUserStatusCommand.java
+++ b/src/main/java/org/asamk/signal/commands/GetUserStatusCommand.java
@@ -21,7 +21,7 @@ public class GetUserStatusCommand implements LocalCommand {
     public void attachToSubparser(final Subparser subparser) {
         subparser.addArgument("number").help("Phone number").nargs("+");
         subparser.help("Check if the specified phone number/s have been registered");
-        subparser.addArgument("--json")
+        subparser.addArgument("-j", "--json")
                 .help("Output received messages in json format, one json object per line.")
                 .action(Arguments.storeTrue());
     }

--- a/src/main/java/org/asamk/signal/commands/GetUserStatusCommand.java
+++ b/src/main/java/org/asamk/signal/commands/GetUserStatusCommand.java
@@ -21,9 +21,6 @@ public class GetUserStatusCommand implements LocalCommand {
     public void attachToSubparser(final Subparser subparser) {
         subparser.addArgument("number").help("Phone number").nargs("+");
         subparser.help("Check if the specified phone number/s have been registered");
-        subparser.addArgument("-j", "--json")
-                .help("Output received messages in json format, one json object per line.")
-                .action(Arguments.storeTrue());
     }
 
     @Override
@@ -47,7 +44,7 @@ public class GetUserStatusCommand implements LocalCommand {
         }
 
         // Output
-        if (ns.getBoolean("json")) {
+        if (ns.getString("output").equals("json")) {
             List<JsonIsRegistered> objects = registered.entrySet()
                     .stream()
                     .map(entry -> new JsonIsRegistered(entry.getKey(), entry.getValue()))

--- a/src/main/java/org/asamk/signal/commands/ListGroupsCommand.java
+++ b/src/main/java/org/asamk/signal/commands/ListGroupsCommand.java
@@ -9,32 +9,61 @@ import org.asamk.signal.manager.groups.GroupInviteLinkUrl;
 import org.asamk.signal.manager.storage.groups.GroupInfo;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ListGroupsCommand implements LocalCommand {
 
-    private static void printGroup(Manager m, GroupInfo group, boolean detailed) {
+    private enum MembersType {
+        MEMBERS,
+        PENDING_MEMBERS,
+        REQUESTING_MEMBERS,
+    }
+
+    private static Set<String> getMembersSet(Manager m, GroupInfo group, MembersType type) {
+        Set<SignalServiceAddress> members;
+        switch (type) {
+            case MEMBERS:
+                members = group.getMembers();
+                break;
+            case PENDING_MEMBERS:
+                members = group.getPendingMembers();
+                break;
+            case REQUESTING_MEMBERS:
+                members = group.getRequestingMembers();
+                break;
+            default:
+                return Collections.emptySet();
+        }
+
+        return members.stream().map(m::resolveSignalServiceAddress)
+                .map(SignalServiceAddress::getLegacyIdentifier)
+                .collect(Collectors.toSet());
+    }
+
+    private static int printGroupsJson(ObjectMapper jsonProcessor, List<?> objects) {
+        try {
+            jsonProcessor.writeValue(System.out, objects);
+            System.out.println();
+        } catch (IOException e) {
+            System.err.println(e.getMessage());
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private static void printGroupPlainText(Manager m, GroupInfo group, boolean detailed) {
         if (detailed) {
-            Set<String> members = group.getMembers()
-                    .stream()
-                    .map(m::resolveSignalServiceAddress)
-                    .map(SignalServiceAddress::getLegacyIdentifier)
-                    .collect(Collectors.toSet());
-
-            Set<String> pendingMembers = group.getPendingMembers()
-                    .stream()
-                    .map(m::resolveSignalServiceAddress)
-                    .map(SignalServiceAddress::getLegacyIdentifier)
-                    .collect(Collectors.toSet());
-
-            Set<String> requestingMembers = group.getRequestingMembers()
-                    .stream()
-                    .map(m::resolveSignalServiceAddress)
-                    .map(SignalServiceAddress::getLegacyIdentifier)
-                    .collect(Collectors.toSet());
-
             final GroupInviteLinkUrl groupInviteLink = group.getGroupInviteLink();
 
             System.out.println(String.format(
@@ -43,9 +72,9 @@ public class ListGroupsCommand implements LocalCommand {
                     group.getTitle(),
                     group.isMember(m.getSelfAddress()),
                     group.isBlocked(),
-                    members,
-                    pendingMembers,
-                    requestingMembers,
+                    getMembersSet(m, group, MembersType.MEMBERS),
+                    getMembersSet(m, group, MembersType.PENDING_MEMBERS),
+                    getMembersSet(m, group, MembersType.REQUESTING_MEMBERS),
                     groupInviteLink == null ? '-' : groupInviteLink.getUrl()));
         } else {
             System.out.println(String.format("Id: %s Name: %s  Active: %s Blocked: %b",
@@ -60,6 +89,9 @@ public class ListGroupsCommand implements LocalCommand {
     public void attachToSubparser(final Subparser subparser) {
         subparser.addArgument("-d", "--detailed").action(Arguments.storeTrue()).help("List members of each group");
         subparser.help("List group name and ids");
+        subparser.addArgument("-j", "--json")
+                .help("Output received messages in json format, one json object per line.")
+                .action(Arguments.storeTrue());
     }
 
     @Override
@@ -72,9 +104,86 @@ public class ListGroupsCommand implements LocalCommand {
         List<GroupInfo> groups = m.getGroups();
         boolean detailed = ns.getBoolean("detailed");
 
-        for (GroupInfo group : groups) {
-            printGroup(m, group, detailed);
+        if (ns.getBoolean("json")) {
+            final ObjectMapper jsonProcessor = new ObjectMapper();
+            jsonProcessor.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+            jsonProcessor.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+
+            if (detailed) {
+                List<JsonListGroupDetailed> objects = new ArrayList<>();
+                for (GroupInfo group : groups) {
+                    final GroupInviteLinkUrl groupInviteLink = group.getGroupInviteLink();
+
+                    objects.add(new JsonListGroupDetailed(group.getGroupId().toBase64(),
+                            group.getTitle(),
+                            group.isMember(m.getSelfAddress()),
+                            group.isBlocked(),
+                            getMembersSet(m, group, MembersType.MEMBERS),
+                            getMembersSet(m, group, MembersType.PENDING_MEMBERS),
+                            getMembersSet(m, group, MembersType.REQUESTING_MEMBERS),
+                            groupInviteLink == null ? null : groupInviteLink.getUrl()));
+                }
+
+                return printGroupsJson(jsonProcessor, objects);
+            } else {
+                List<JsonListGroup> objects = groups.stream().map(
+                        group -> new JsonListGroup(group.getGroupId().toBase64(),
+                                group.getTitle(),
+                                group.isMember(m.getSelfAddress()),
+                                group.isBlocked()))
+                        .collect(Collectors.toList());
+
+                return printGroupsJson(jsonProcessor, objects);
+            }
+        } else {
+            for (GroupInfo group : groups) {
+                printGroupPlainText(m, group, detailed);
+            }
         }
+
         return 0;
+    }
+
+    private static final class JsonListGroup {
+
+        public String id;
+        public String name;
+        public boolean isMember;
+        public boolean isBlocked;
+
+        public JsonListGroup(String id, String name, boolean isMember, boolean isBlocked) {
+            this.id = id;
+            this.name = name;
+            this.isMember = isMember;
+            this.isBlocked = isBlocked;
+        }
+    }
+
+    private static final class JsonListGroupDetailed {
+
+        public String id;
+        public String name;
+        public boolean isMember;
+        public boolean isBlocked;
+
+        public Set<String> members;
+        public Set<String> pendingMembers;
+        public Set<String> requestingMembers;
+        public String groupInviteLink;
+
+        public JsonListGroupDetailed(String id, String name, boolean isMember, boolean isBlocked,
+                                      Set<String> members, Set<String> pendingMembers,
+                                      Set<String> requestingMembers, String groupInviteLink)
+        {
+            this.id = id;
+            this.name = name;
+            this.isMember = isMember;
+            this.isBlocked = isBlocked;
+
+            this.members = members;
+            this.pendingMembers = pendingMembers;
+            this.requestingMembers = requestingMembers;
+            this.groupInviteLink = groupInviteLink;
+        }
     }
 }

--- a/src/main/java/org/asamk/signal/commands/ListGroupsCommand.java
+++ b/src/main/java/org/asamk/signal/commands/ListGroupsCommand.java
@@ -110,11 +110,11 @@ public class ListGroupsCommand implements LocalCommand {
             jsonProcessor.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
 
             if (detailed) {
-                List<JsonListGroupDetailed> objects = new ArrayList<>();
+                List<JsonGroupDetailed> objects = new ArrayList<>();
                 for (GroupInfo group : groups) {
                     final GroupInviteLinkUrl groupInviteLink = group.getGroupInviteLink();
 
-                    objects.add(new JsonListGroupDetailed(group.getGroupId().toBase64(),
+                    objects.add(new JsonGroupDetailed(group.getGroupId().toBase64(),
                             group.getTitle(),
                             group.isMember(m.getSelfAddress()),
                             group.isBlocked(),
@@ -126,8 +126,8 @@ public class ListGroupsCommand implements LocalCommand {
 
                 return printGroupsJson(jsonProcessor, objects);
             } else {
-                List<JsonListGroup> objects = groups.stream().map(
-                        group -> new JsonListGroup(group.getGroupId().toBase64(),
+                List<JsonGroup> objects = groups.stream().map(
+                        group -> new JsonGroup(group.getGroupId().toBase64(),
                                 group.getTitle(),
                                 group.isMember(m.getSelfAddress()),
                                 group.isBlocked()))
@@ -144,14 +144,14 @@ public class ListGroupsCommand implements LocalCommand {
         return 0;
     }
 
-    private static final class JsonListGroup {
+    private static final class JsonGroup {
 
         public String id;
         public String name;
         public boolean isMember;
         public boolean isBlocked;
 
-        public JsonListGroup(String id, String name, boolean isMember, boolean isBlocked) {
+        public JsonGroup(String id, String name, boolean isMember, boolean isBlocked) {
             this.id = id;
             this.name = name;
             this.isMember = isMember;
@@ -159,7 +159,7 @@ public class ListGroupsCommand implements LocalCommand {
         }
     }
 
-    private static final class JsonListGroupDetailed {
+    private static final class JsonGroupDetailed {
 
         public String id;
         public String name;
@@ -171,9 +171,9 @@ public class ListGroupsCommand implements LocalCommand {
         public Set<String> requestingMembers;
         public String groupInviteLink;
 
-        public JsonListGroupDetailed(String id, String name, boolean isMember, boolean isBlocked,
-                                      Set<String> members, Set<String> pendingMembers,
-                                      Set<String> requestingMembers, String groupInviteLink)
+        public JsonGroupDetailed(String id, String name, boolean isMember, boolean isBlocked,
+                                 Set<String> members, Set<String> pendingMembers,
+                                 Set<String> requestingMembers, String groupInviteLink)
         {
             this.id = id;
             this.name = name;

--- a/src/main/java/org/asamk/signal/commands/ListGroupsCommand.java
+++ b/src/main/java/org/asamk/signal/commands/ListGroupsCommand.java
@@ -16,36 +16,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ListGroupsCommand implements LocalCommand {
 
-    private enum MembersType {
-        MEMBERS,
-        PENDING_MEMBERS,
-        REQUESTING_MEMBERS,
-    }
-
-    private static Set<String> getMembersSet(Manager m, GroupInfo group, MembersType type) {
-        Set<SignalServiceAddress> members;
-        switch (type) {
-            case MEMBERS:
-                members = group.getMembers();
-                break;
-            case PENDING_MEMBERS:
-                members = group.getPendingMembers();
-                break;
-            case REQUESTING_MEMBERS:
-                members = group.getRequestingMembers();
-                break;
-            default:
-                return Collections.emptySet();
-        }
-
-        return members.stream().map(m::resolveSignalServiceAddress)
+    private static Set<String> resolveMembers(Manager m, Set<SignalServiceAddress> addresses) {
+        return addresses.stream().map(m::resolveSignalServiceAddress)
                 .map(SignalServiceAddress::getLegacyIdentifier)
                 .collect(Collectors.toSet());
     }
@@ -72,9 +50,9 @@ public class ListGroupsCommand implements LocalCommand {
                     group.getTitle(),
                     group.isMember(m.getSelfAddress()),
                     group.isBlocked(),
-                    getMembersSet(m, group, MembersType.MEMBERS),
-                    getMembersSet(m, group, MembersType.PENDING_MEMBERS),
-                    getMembersSet(m, group, MembersType.REQUESTING_MEMBERS),
+                    resolveMembers(m, group.getMembers()),
+                    resolveMembers(m, group.getPendingMembers()),
+                    resolveMembers(m, group.getRequestingMembers()),
                     groupInviteLink == null ? '-' : groupInviteLink.getUrl()));
         } else {
             System.out.println(String.format("Id: %s Name: %s  Active: %s Blocked: %b",
@@ -87,11 +65,10 @@ public class ListGroupsCommand implements LocalCommand {
 
     @Override
     public void attachToSubparser(final Subparser subparser) {
-        subparser.addArgument("-d", "--detailed").action(Arguments.storeTrue()).help("List members of each group");
-        subparser.help("List group name and ids");
-        subparser.addArgument("-j", "--json")
-                .help("Output received messages in json format, one json object per line.")
-                .action(Arguments.storeTrue());
+        subparser.addArgument("-d", "--detailed").action(Arguments.storeTrue())
+                .help("List the members and group invite links of each group");
+
+        subparser.help("List group information including names, ids, active status, blocked status and members");
     }
 
     @Override
@@ -101,42 +78,29 @@ public class ListGroupsCommand implements LocalCommand {
             return 1;
         }
 
-        List<GroupInfo> groups = m.getGroups();
-        boolean detailed = ns.getBoolean("detailed");
-
-        if (ns.getBoolean("json")) {
+        if (ns.getString("output").equals("json")) {
             final ObjectMapper jsonProcessor = new ObjectMapper();
             jsonProcessor.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
             jsonProcessor.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
 
-            if (detailed) {
-                List<JsonGroupDetailed> objects = new ArrayList<>();
-                for (GroupInfo group : groups) {
-                    final GroupInviteLinkUrl groupInviteLink = group.getGroupInviteLink();
+            List<JsonGroup> objects = new ArrayList<>();
+            for (GroupInfo group : m.getGroups()) {
+                final GroupInviteLinkUrl groupInviteLink = group.getGroupInviteLink();
 
-                    objects.add(new JsonGroupDetailed(group.getGroupId().toBase64(),
-                            group.getTitle(),
-                            group.isMember(m.getSelfAddress()),
-                            group.isBlocked(),
-                            getMembersSet(m, group, MembersType.MEMBERS),
-                            getMembersSet(m, group, MembersType.PENDING_MEMBERS),
-                            getMembersSet(m, group, MembersType.REQUESTING_MEMBERS),
-                            groupInviteLink == null ? null : groupInviteLink.getUrl()));
-                }
-
-                return printGroupsJson(jsonProcessor, objects);
-            } else {
-                List<JsonGroup> objects = groups.stream().map(
-                        group -> new JsonGroup(group.getGroupId().toBase64(),
-                                group.getTitle(),
-                                group.isMember(m.getSelfAddress()),
-                                group.isBlocked()))
-                        .collect(Collectors.toList());
-
-                return printGroupsJson(jsonProcessor, objects);
+                objects.add(new JsonGroup(group.getGroupId().toBase64(),
+                        group.getTitle(),
+                        group.isMember(m.getSelfAddress()),
+                        group.isBlocked(),
+                        resolveMembers(m, group.getMembers()),
+                        resolveMembers(m, group.getPendingMembers()),
+                        resolveMembers(m, group.getRequestingMembers()),
+                        groupInviteLink == null ? null : groupInviteLink.getUrl()));
             }
+
+            return printGroupsJson(jsonProcessor, objects);
         } else {
-            for (GroupInfo group : groups) {
+            boolean detailed = ns.getBoolean("detailed");
+            for (GroupInfo group : m.getGroups()) {
                 printGroupPlainText(m, group, detailed);
             }
         }
@@ -151,29 +115,14 @@ public class ListGroupsCommand implements LocalCommand {
         public boolean isMember;
         public boolean isBlocked;
 
-        public JsonGroup(String id, String name, boolean isMember, boolean isBlocked) {
-            this.id = id;
-            this.name = name;
-            this.isMember = isMember;
-            this.isBlocked = isBlocked;
-        }
-    }
-
-    private static final class JsonGroupDetailed {
-
-        public String id;
-        public String name;
-        public boolean isMember;
-        public boolean isBlocked;
-
         public Set<String> members;
         public Set<String> pendingMembers;
         public Set<String> requestingMembers;
         public String groupInviteLink;
 
-        public JsonGroupDetailed(String id, String name, boolean isMember, boolean isBlocked,
-                                 Set<String> members, Set<String> pendingMembers,
-                                 Set<String> requestingMembers, String groupInviteLink)
+        public JsonGroup(String id, String name, boolean isMember, boolean isBlocked,
+                         Set<String> members, Set<String> pendingMembers,
+                         Set<String> requestingMembers, String groupInviteLink)
         {
             this.id = id;
             this.name = name;

--- a/src/main/java/org/asamk/signal/commands/ListGroupsCommand.java
+++ b/src/main/java/org/asamk/signal/commands/ListGroupsCommand.java
@@ -73,11 +73,6 @@ public class ListGroupsCommand implements LocalCommand {
 
     @Override
     public int handleCommand(final Namespace ns, final Manager m) {
-        if (!m.isRegistered()) {
-            System.err.println("User is not registered.");
-            return 1;
-        }
-
         if (ns.getString("output").equals("json")) {
             final ObjectMapper jsonProcessor = new ObjectMapper();
             jsonProcessor.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);

--- a/src/main/java/org/asamk/signal/commands/ListGroupsCommand.java
+++ b/src/main/java/org/asamk/signal/commands/ListGroupsCommand.java
@@ -66,7 +66,7 @@ public class ListGroupsCommand implements LocalCommand {
     @Override
     public void attachToSubparser(final Subparser subparser) {
         subparser.addArgument("-d", "--detailed").action(Arguments.storeTrue())
-                .help("List the members and group invite links of each group");
+                .help("List the members and group invite links of each group. If output=json, then this is always set");
 
         subparser.help("List group information including names, ids, active status, blocked status and members");
     }

--- a/src/main/java/org/asamk/signal/commands/ReceiveCommand.java
+++ b/src/main/java/org/asamk/signal/commands/ReceiveCommand.java
@@ -35,7 +35,7 @@ public class ReceiveCommand implements ExtendedDbusCommand, LocalCommand {
         subparser.addArgument("--ignore-attachments")
                 .help("Don’t download attachments of received messages.")
                 .action(Arguments.storeTrue());
-        subparser.addArgument("--json")
+        subparser.addArgument("-j", "--json")
                 .help("Output received messages in json format, one json object per line.")
                 .action(Arguments.storeTrue());
     }

--- a/src/main/java/org/asamk/signal/commands/ReceiveCommand.java
+++ b/src/main/java/org/asamk/signal/commands/ReceiveCommand.java
@@ -20,12 +20,19 @@ import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.whispersystems.util.Base64;
 
+// TODO delete later when "json" variable is removed
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import static org.asamk.signal.util.ErrorUtils.handleAssertionError;
 
 public class ReceiveCommand implements ExtendedDbusCommand, LocalCommand {
+
+    // TODO delete later when "json" variable is removed
+    final static Logger logger = LoggerFactory.getLogger(ReceiveCommand.class);
 
     @Override
     public void attachToSubparser(final Subparser subparser) {
@@ -44,6 +51,11 @@ public class ReceiveCommand implements ExtendedDbusCommand, LocalCommand {
         final ObjectMapper jsonProcessor;
 
         boolean inJson = ns.getString("output").equals("json") || ns.getBoolean("json");
+
+        // TODO delete later when "json" variable is removed
+        if (ns.getBoolean("json")) {
+            logger.warn("\"--json\" option has been deprecated, please use \"output\" instead.");
+        }
 
         if (inJson) {
             jsonProcessor = new ObjectMapper();
@@ -150,6 +162,11 @@ public class ReceiveCommand implements ExtendedDbusCommand, LocalCommand {
     @Override
     public int handleCommand(final Namespace ns, final Manager m) {
         boolean inJson = ns.getString("output").equals("json") || ns.getBoolean("json");
+
+        // TODO delete later when "json" variable is removed
+        if (ns.getBoolean("json")) {
+            logger.warn("\"--json\" option has been deprecated, please use \"output\" instead.");
+        }
 
         double timeout = 5;
         if (ns.getDouble("timeout") != null) {

--- a/src/main/java/org/asamk/signal/commands/ReceiveCommand.java
+++ b/src/main/java/org/asamk/signal/commands/ReceiveCommand.java
@@ -35,14 +35,11 @@ public class ReceiveCommand implements ExtendedDbusCommand, LocalCommand {
         subparser.addArgument("--ignore-attachments")
                 .help("Don’t download attachments of received messages.")
                 .action(Arguments.storeTrue());
-        subparser.addArgument("-j", "--json")
-                .help("Output received messages in json format, one json object per line.")
-                .action(Arguments.storeTrue());
     }
 
     public int handleCommand(final Namespace ns, final Signal signal, DBusConnection dbusconnection) {
         final ObjectMapper jsonProcessor;
-        if (ns.getBoolean("json")) {
+        if (ns.getString("output").equals("json")) {
             jsonProcessor = new ObjectMapper();
             jsonProcessor.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
             jsonProcessor.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
@@ -161,7 +158,7 @@ public class ReceiveCommand implements ExtendedDbusCommand, LocalCommand {
         }
         boolean ignoreAttachments = ns.getBoolean("ignore_attachments");
         try {
-            final Manager.ReceiveMessageHandler handler = ns.getBoolean("json")
+            final Manager.ReceiveMessageHandler handler = ns.getString("output").equals("json")
                     ? new JsonReceiveMessageHandler(m)
                     : new ReceiveMessageHandler(m);
             m.receiveMessages((long) (timeout * 1000),

--- a/src/main/java/org/asamk/signal/manager/Manager.java
+++ b/src/main/java/org/asamk/signal/manager/Manager.java
@@ -340,7 +340,7 @@ public class Manager implements Closeable {
      *
      * @param numbers The set of phone number in question
      * @return A map of numbers to booleans. True if registered, false otherwise. Should never be null
-     * @throws IOException if its unable to check if the users are registered
+     * @throws IOException if its unable to get the contacts to check if they're registered
      */
     public Map<String, Boolean> areUsersRegistered(Set<String> numbers) throws IOException {
         // Note "contactDetails" has no optionals. It only gives us info on users who are registered


### PR DESCRIPTION
This works both with and without `--detailed`. Depending on the presence of that parameter, it will either output a list of `JsonGroup` objects, or in detailed mode it will output a list of `JsonGroupDetailed` objects.

Aside from the fact its in JSON, the only differences between `--json` output and normal one is that "Active" is referred to as `isMember` and the group invite link will instead be `null` instead of `"-"` when no link is present.

I used streams instead of for-loops where possible, but due to the invite link stuff in JSON-detailed mode, I felt a for-loop was less cluttered than the alternative streamed version.

If you want me to change these or anything else, let me know.