### PR TITLE
Added sticker info to json output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ local.properties
 .project
 .settings/
 out/
+.DS_Store

--- a/src/main/java/org/asamk/signal/json/JsonDataMessage.java
+++ b/src/main/java/org/asamk/signal/json/JsonDataMessage.java
@@ -19,6 +19,7 @@ class JsonDataMessage {
     JsonQuote quote;
     List<JsonMention> mentions;
     List<JsonAttachment> attachments;
+    JsonSticker sticker;
     JsonGroupInfo groupInfo;
 
     JsonDataMessage(SignalServiceDataMessage dataMessage, Manager m) {
@@ -60,15 +61,19 @@ class JsonDataMessage {
         } else {
             this.attachments = List.of();
         }
+        if (dataMessage.getSticker().isPresent()) {
+            this.sticker = new JsonSticker(dataMessage.getSticker().get());
+        }
     }
 
     public JsonDataMessage(Signal.MessageReceived messageReceived) {
         timestamp = messageReceived.getTimestamp();
         message = messageReceived.getMessage();
         groupInfo = new JsonGroupInfo(messageReceived.getGroupId());
-        reaction = null;    // TODO Replace these 3 with the proper commands
+        reaction = null;    // TODO Replace these 4 with the proper commands
         quote = null;
         mentions = null;
+        sticker = null;
         attachments = messageReceived.getAttachments().stream().map(JsonAttachment::new).collect(Collectors.toList());
     }
 
@@ -76,9 +81,10 @@ class JsonDataMessage {
         timestamp = messageReceived.getTimestamp();
         message = messageReceived.getMessage();
         groupInfo = new JsonGroupInfo(messageReceived.getGroupId());
-        reaction = null;    // TODO Replace these 3 with the proper commands
+        reaction = null;    // TODO Replace these 4 with the proper commands
         quote = null;
         mentions = null;
+        sticker = null;
         attachments = messageReceived.getAttachments().stream().map(JsonAttachment::new).collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/asamk/signal/json/JsonSticker.java
+++ b/src/main/java/org/asamk/signal/json/JsonSticker.java
@@ -1,0 +1,18 @@
+package org.asamk.signal.json;
+
+import org.whispersystems.signalservice.api.messages.SignalServiceDataMessage;
+import org.whispersystems.util.Base64;
+
+public class JsonSticker {
+
+    String packId;
+    String packKey;
+    int stickerId;
+
+    public JsonSticker(SignalServiceDataMessage.Sticker sticker) {
+        this.packId = Base64.encodeBytes(sticker.getPackId());
+        this.packKey = Base64.encodeBytes(sticker.getPackKey());
+        this.stickerId = sticker.getStickerId();
+        // TODO also download sticker image ??
+    }
+}


### PR DESCRIPTION
Note that this doesn't actually implement #410 , instead this just adds the current 3 sticker fields to json output when running.

`signal-cli --output=json -u +61XXXXXXXX receive`