### PR TITLE
Added GraalVM configuration to build a native binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ dependencies. If you have a recent gradle version installed, you can replace `./
 
         ./gradlew distTar
 
+### Building a native binary with GraalVM
+
+It is possible to build a native binary with [GraalVM](https://www.graalvm.org).
+
+1. [Install GraalVM and setup the enviroment](https://www.graalvm.org/docs/getting-started/#install-graalvm)
+2. [Install prerequisites](https://www.graalvm.org/reference-manual/native-image/#prerequisites)
+2. Execute Gradle:
+
+        ./gradle nativeImage
+  
+   The binary is available at
+
+        build/native-image/signal-cli
+
 ## Troubleshooting
 If you use a version of the Oracle JRE and get an InvalidKeyException you need to enable unlimited strength crypto. See https://stackoverflow.com/questions/6481627/java-security-illegal-key-size-or-default-parameters for instructions.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
-apply plugin: 'java'
-apply plugin: 'application'
-apply plugin: 'eclipse'
+plugins {
+    id 'java'
+    id 'application'
+    id 'eclipse'
+    id 'org.mikeneck.graalvm-native-image' version 'v1.0.0'
+}
 
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
@@ -22,6 +25,27 @@ dependencies {
     implementation 'net.sourceforge.argparse4j:argparse4j:0.8.1'
     implementation 'com.github.hypfvieh:dbus-java:3.2.4'
     implementation 'org.slf4j:slf4j-simple:1.7.30'
+}
+
+nativeImage {
+  mainClass = mainClassName
+  executableName = 'signal-cli'
+  arguments(
+    "--no-fallback",
+    "--allow-incomplete-classpath",
+    "--report-unsupported-elements-at-runtime",
+    "--enable-url-protocols=http,https",
+    "--enable-https",
+    "--enable-all-security-services",
+    "-J-Djavax.net.ssl.trustStore=/root/graalvm-ce-java11-20.3.0/lib/security/cacerts",
+    "-J-Djavax.net.ssl.trustAnchors=/root/graalvm-ce-java11-20.3.0/lib/security/cacerts",
+    "-J-Djavax.net.ssl.trustStorePassword=changeit",
+    "-Djavax.net.ssl.trustStore=/root/graalvm-ce-java11-20.3.0/lib/security/cacerts",
+    "-Djavax.net.ssl.trustAnchors=/root/graalvm-ce-java11-20.3.0/lib/security/cacerts",
+    "-Djavax.net.ssl.trustStorePassword=changeit",
+    "-H:ResourceConfigurationFiles=graalvm-config-dir/resource-config.json",
+    "-H:ReflectionConfigurationFiles=graalvm-config-dir/reflect-config.json"
+  )
 }
 
 jar {

--- a/graalvm-config-dir/reflect-config.json
+++ b/graalvm-config-dir/reflect-config.json
@@ -1,0 +1,1387 @@
+[
+{
+  "name":"byte[]"
+},
+{
+  "name":"char[]"
+},
+{
+  "name":"com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.AESCipher$General",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.DHParameters",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.HmacCore$HmacSHA256",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.TlsKeyMaterialGenerator",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.TlsMasterSecretGenerator",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.TlsPrfGenerator$V12",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"java.io.Serializable",
+  "allDeclaredMethods":true
+},
+{
+  "name":"java.lang.Comparable",
+  "allDeclaredMethods":true
+},
+{
+  "name":"java.lang.Double",
+  "methods":[{"name":"valueOf","parameterTypes":["java.lang.String"] }]
+},
+{
+  "name":"java.lang.Integer",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"java.lang.Number",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true
+},
+{
+  "name":"java.nio.Buffer",
+  "fields":[{"name":"address", "allowUnsafeAccess":true}]
+},
+{
+  "name":"java.security.KeyStoreSpi"
+},
+{
+  "name":"java.security.SecureRandomParameters"
+},
+{
+  "name":"java.security.cert.PKIXRevocationChecker"
+},
+{
+  "name":"java.security.interfaces.ECPrivateKey"
+},
+{
+  "name":"java.security.interfaces.ECPublicKey"
+},
+{
+  "name":"java.security.interfaces.RSAPrivateKey"
+},
+{
+  "name":"java.security.interfaces.RSAPublicKey"
+},
+{
+  "name":"java.util.ArrayList",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"java.util.Locale",
+  "methods":[{"name":"getUnicodeLocaleType","parameterTypes":["java.lang.String"] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.contacts.ContactInfo",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.manager.storage.contacts.JsonContactsStore",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.manager.storage.groups.GroupInfo",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true
+},
+{
+  "name":"org.asamk.signal.manager.storage.groups.GroupInfoV1",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.manager.storage.groups.GroupInfoV1$MembersDeserializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.groups.GroupInfoV1$MembersSerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.groups.JsonGroupStore",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true,
+  "fields":[
+    {"name":"groups", "allowWrite":true}
+  ],
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.manager.storage.groups.JsonGroupStore$GroupsDeserializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.groups.JsonGroupStore$GroupsSerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.profiles.ProfileStore",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true,
+  "fields":[
+    {"name":"profiles", "allowWrite":true}
+  ]
+},
+{
+  "name":"org.asamk.signal.manager.storage.profiles.ProfileStore$ProfileStoreDeserializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.profiles.ProfileStore$ProfileStoreSerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.profiles.SignalProfile",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.manager.storage.profiles.SignalProfile$Capabilities",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.JsonIdentityKeyStore$JsonIdentityKeyStoreDeserializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.JsonIdentityKeyStore$JsonIdentityKeyStoreSerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.JsonPreKeyStore$JsonPreKeyStoreDeserializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.JsonPreKeyStore$JsonPreKeyStoreSerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.JsonSessionStore$JsonSessionStoreDeserializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.JsonSessionStore$JsonSessionStoreSerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.JsonSignalProtocolStore",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.JsonSignedPreKeyStore$JsonSignedPreKeyStoreDeserializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.JsonSignedPreKeyStore$JsonSignedPreKeyStoreSerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.RecipientStore",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true,
+  "fields":[
+    {"name":"addresses", "allowWrite":true}
+  ]
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.RecipientStore$RecipientStoreDeserializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.protocol.RecipientStore$RecipientStoreSerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.stickers.StickerStore",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true,
+  "fields":[
+    {"name":"stickers", "allowWrite":true}
+  ]
+},
+{
+  "name":"org.asamk.signal.manager.storage.stickers.StickerStore$StickersDeserializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.manager.storage.stickers.StickerStore$StickersSerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.asamk.signal.util.SecurityProvider$DefaultRandom",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.COMPOSITE$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.DH$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.DSA$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.DSTU4145$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.EC$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.ECGOST$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.EdEC$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.ElGamal$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.GM$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.GOST$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.IES$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.RSA$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.X509$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.edec.SignatureSpi$Ed25519",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.edec.SignatureSpi$Ed448",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.Blake2b$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.Blake2s$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.DSTU7564$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.GOST3411$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.Haraka$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.Keccak$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.MD2$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.MD4$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.MD5$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.RIPEMD128$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.RIPEMD160$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.RIPEMD256$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.RIPEMD320$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.SHA1$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.SHA224$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.SHA256$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.SHA3$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.SHA384$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.SHA512$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.SM3$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.Skein$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.Tiger$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.digest.Whirlpool$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.drbg.DRBG$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.keystore.BC$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.keystore.BCFKS$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.keystore.PKCS12$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.keystore.bc.BcKeyStoreSpi$Std",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.AES$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.ARC4$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.ARIA$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Blowfish$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.CAST5$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.CAST6$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Camellia$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.ChaCha$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.DES$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.DESede$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.DSTU7624$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.GOST28147$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.GOST3412_2015$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Grain128$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Grainv1$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.HC128$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.HC256$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.IDEA$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Noekeon$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.OpenSSLPBKDF$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF1$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF2$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.PBEPKCS12$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Poly1305$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.RC2$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.RC5$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.RC6$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Rijndael$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.SCRYPT$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.SEED$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.SM4$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Salsa20$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Serpent$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Shacal2$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.SipHash$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.SipHash128$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Skipjack$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.TEA$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.TLSKDF$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Threefish$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Twofish$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.VMPC$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.VMPCKSA3$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.XSalsa20$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.XTEA$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.bouncycastle.jcajce.provider.symmetric.Zuc$Mappings",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.signal.libsignal.metadata.SignalProtos$SenderCertificate",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"certificate_", "allowUnsafeAccess":true}, 
+    {"name":"signature_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.libsignal.metadata.SignalProtos$SenderCertificate$Certificate",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"expires_", "allowUnsafeAccess":true}, 
+    {"name":"identityKey_", "allowUnsafeAccess":true}, 
+    {"name":"senderDevice_", "allowUnsafeAccess":true}, 
+    {"name":"senderE164_", "allowUnsafeAccess":true}, 
+    {"name":"senderUuid_", "allowUnsafeAccess":true}, 
+    {"name":"signer_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.libsignal.metadata.SignalProtos$ServerCertificate",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"certificate_", "allowUnsafeAccess":true}, 
+    {"name":"signature_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.libsignal.metadata.SignalProtos$ServerCertificate$Certificate",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"id_", "allowUnsafeAccess":true}, 
+    {"name":"key_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.storageservice.protos.groups.AccessControl",
+  "fields":[
+    {"name":"addFromInviteLink_", "allowUnsafeAccess":true}, 
+    {"name":"attributes_", "allowUnsafeAccess":true}, 
+    {"name":"members_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.storageservice.protos.groups.Group",
+  "fields":[
+    {"name":"accessControl_", "allowUnsafeAccess":true}, 
+    {"name":"avatar_", "allowUnsafeAccess":true}, 
+    {"name":"disappearingMessagesTimer_", "allowUnsafeAccess":true}, 
+    {"name":"inviteLinkPassword_", "allowUnsafeAccess":true}, 
+    {"name":"members_", "allowUnsafeAccess":true}, 
+    {"name":"pendingMembers_", "allowUnsafeAccess":true}, 
+    {"name":"publicKey_", "allowUnsafeAccess":true}, 
+    {"name":"requestingMembers_", "allowUnsafeAccess":true}, 
+    {"name":"revision_", "allowUnsafeAccess":true}, 
+    {"name":"title_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.storageservice.protos.groups.GroupAttributeBlob",
+  "fields":[
+    {"name":"contentCase_", "allowUnsafeAccess":true}, 
+    {"name":"content_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.storageservice.protos.groups.Member",
+  "fields":[
+    {"name":"joinedAtRevision_", "allowUnsafeAccess":true}, 
+    {"name":"presentation_", "allowUnsafeAccess":true}, 
+    {"name":"profileKey_", "allowUnsafeAccess":true}, 
+    {"name":"role_", "allowUnsafeAccess":true}, 
+    {"name":"userId_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.storageservice.protos.groups.PendingMember",
+  "fields":[
+    {"name":"addedByUserId_", "allowUnsafeAccess":true}, 
+    {"name":"member_", "allowUnsafeAccess":true}, 
+    {"name":"timestamp_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.storageservice.protos.groups.RequestingMember",
+  "fields":[
+    {"name":"presentation_", "allowUnsafeAccess":true}, 
+    {"name":"profileKey_", "allowUnsafeAccess":true}, 
+    {"name":"timestamp_", "allowUnsafeAccess":true}, 
+    {"name":"userId_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.storageservice.protos.groups.local.DecryptedGroup",
+  "fields":[
+    {"name":"accessControl_", "allowUnsafeAccess":true}, 
+    {"name":"avatar_", "allowUnsafeAccess":true}, 
+    {"name":"disappearingMessagesTimer_", "allowUnsafeAccess":true}, 
+    {"name":"inviteLinkPassword_", "allowUnsafeAccess":true}, 
+    {"name":"members_", "allowUnsafeAccess":true}, 
+    {"name":"pendingMembers_", "allowUnsafeAccess":true}, 
+    {"name":"requestingMembers_", "allowUnsafeAccess":true}, 
+    {"name":"revision_", "allowUnsafeAccess":true}, 
+    {"name":"title_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.storageservice.protos.groups.local.DecryptedMember",
+  "fields":[
+    {"name":"joinedAtRevision_", "allowUnsafeAccess":true}, 
+    {"name":"profileKey_", "allowUnsafeAccess":true}, 
+    {"name":"role_", "allowUnsafeAccess":true}, 
+    {"name":"uuid_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.storageservice.protos.groups.local.DecryptedPendingMember",
+  "fields":[
+    {"name":"addedByUuid_", "allowUnsafeAccess":true}, 
+    {"name":"role_", "allowUnsafeAccess":true}, 
+    {"name":"timestamp_", "allowUnsafeAccess":true}, 
+    {"name":"uuidCipherText_", "allowUnsafeAccess":true}, 
+    {"name":"uuid_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.storageservice.protos.groups.local.DecryptedRequestingMember",
+  "fields":[
+    {"name":"profileKey_", "allowUnsafeAccess":true}, 
+    {"name":"timestamp_", "allowUnsafeAccess":true}, 
+    {"name":"uuid_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.signal.storageservice.protos.groups.local.DecryptedTimer",
+  "fields":[{"name":"duration_", "allowUnsafeAccess":true}]
+},
+{
+  "name":"org.whispersystems.curve25519.OpportunisticCurve25519Provider",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.whispersystems.libsignal.fingerprint.FingerprintProtos$CombinedFingerprints",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"localFingerprint_", "allowUnsafeAccess":true}, 
+    {"name":"remoteFingerprint_", "allowUnsafeAccess":true}, 
+    {"name":"version_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.fingerprint.FingerprintProtos$LogicalFingerprint",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"content_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.protocol.SignalProtos$PreKeySignalMessage",
+  "fields":[
+    {"name":"baseKey_", "allowUnsafeAccess":true}, 
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"identityKey_", "allowUnsafeAccess":true}, 
+    {"name":"message_", "allowUnsafeAccess":true}, 
+    {"name":"preKeyId_", "allowUnsafeAccess":true}, 
+    {"name":"registrationId_", "allowUnsafeAccess":true}, 
+    {"name":"signedPreKeyId_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.protocol.SignalProtos$SignalMessage",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"ciphertext_", "allowUnsafeAccess":true}, 
+    {"name":"counter_", "allowUnsafeAccess":true}, 
+    {"name":"previousCounter_", "allowUnsafeAccess":true}, 
+    {"name":"ratchetKey_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.state.IdentityKeyStore",
+  "allDeclaredMethods":true
+},
+{
+  "name":"org.whispersystems.libsignal.state.PreKeyStore",
+  "allDeclaredMethods":true
+},
+{
+  "name":"org.whispersystems.libsignal.state.SessionStore",
+  "allDeclaredMethods":true
+},
+{
+  "name":"org.whispersystems.libsignal.state.SignalProtocolStore",
+  "allDeclaredMethods":true
+},
+{
+  "name":"org.whispersystems.libsignal.state.SignedPreKeyStore",
+  "allDeclaredMethods":true
+},
+{
+  "name":"org.whispersystems.libsignal.state.StorageProtos$IdentityKeyPairStructure",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"privateKey_", "allowUnsafeAccess":true}, 
+    {"name":"publicKey_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.state.StorageProtos$PreKeyRecordStructure",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"id_", "allowUnsafeAccess":true}, 
+    {"name":"privateKey_", "allowUnsafeAccess":true}, 
+    {"name":"publicKey_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.state.StorageProtos$RecordStructure",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"currentSession_", "allowUnsafeAccess":true}, 
+    {"name":"previousSessions_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.state.StorageProtos$SessionStructure",
+  "fields":[
+    {"name":"aliceBaseKey_", "allowUnsafeAccess":true}, 
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"localIdentityPublic_", "allowUnsafeAccess":true}, 
+    {"name":"localRegistrationId_", "allowUnsafeAccess":true}, 
+    {"name":"needsRefresh_", "allowUnsafeAccess":true}, 
+    {"name":"pendingKeyExchange_", "allowUnsafeAccess":true}, 
+    {"name":"pendingPreKey_", "allowUnsafeAccess":true}, 
+    {"name":"previousCounter_", "allowUnsafeAccess":true}, 
+    {"name":"receiverChains_", "allowUnsafeAccess":true}, 
+    {"name":"remoteIdentityPublic_", "allowUnsafeAccess":true}, 
+    {"name":"remoteRegistrationId_", "allowUnsafeAccess":true}, 
+    {"name":"rootKey_", "allowUnsafeAccess":true}, 
+    {"name":"senderChain_", "allowUnsafeAccess":true}, 
+    {"name":"sessionVersion_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.state.StorageProtos$SessionStructure$Chain",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"chainKey_", "allowUnsafeAccess":true}, 
+    {"name":"messageKeys_", "allowUnsafeAccess":true}, 
+    {"name":"senderRatchetKeyPrivate_", "allowUnsafeAccess":true}, 
+    {"name":"senderRatchetKey_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.state.StorageProtos$SessionStructure$Chain$ChainKey",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"index_", "allowUnsafeAccess":true}, 
+    {"name":"key_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.state.StorageProtos$SessionStructure$Chain$MessageKey",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"cipherKey_", "allowUnsafeAccess":true}, 
+    {"name":"index_", "allowUnsafeAccess":true}, 
+    {"name":"iv_", "allowUnsafeAccess":true}, 
+    {"name":"macKey_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.state.StorageProtos$SessionStructure$PendingPreKey",
+  "fields":[
+    {"name":"baseKey_", "allowUnsafeAccess":true}, 
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"preKeyId_", "allowUnsafeAccess":true}, 
+    {"name":"signedPreKeyId_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.libsignal.state.StorageProtos$SignedPreKeyRecordStructure",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"id_", "allowUnsafeAccess":true}, 
+    {"name":"privateKey_", "allowUnsafeAccess":true}, 
+    {"name":"publicKey_", "allowUnsafeAccess":true}, 
+    {"name":"signature_", "allowUnsafeAccess":true}, 
+    {"name":"timestamp_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.api.account.AccountAttributes",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.api.account.AccountAttributes$Capabilities",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.api.groupsv2.CredentialResponse",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.api.groupsv2.TemporalCredential",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.api.groupsv2.TemporalCredential[]"
+},
+{
+  "name":"org.whispersystems.signalservice.api.messages.multidevice.DeviceInfo",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.api.profiles.SignalServiceProfile",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.api.profiles.SignalServiceProfile$Capabilities",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.api.push.SignedPreKeyEntity",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.api.push.SignedPreKeyEntity$ByteArraySerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.contacts.crypto.SignatureBodyEntity",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.contacts.entities.KeyBackupRequest",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.contacts.entities.KeyBackupResponse",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.contacts.entities.RemoteAttestationRequest",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.contacts.entities.RemoteAttestationResponse",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.contacts.entities.TokenResponse",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.keybackup.protos.DeleteRequest",
+  "fields":[
+    {"name":"backupId_", "allowUnsafeAccess":true}, 
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"serviceId_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.keybackup.protos.Request",
+  "fields":[
+    {"name":"backup_", "allowUnsafeAccess":true}, 
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"delete_", "allowUnsafeAccess":true}, 
+    {"name":"restore_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.AuthCredentials",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.ConfirmCodeMessage",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.DeviceCode",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.DeviceId",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.DeviceInfoList",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.OutgoingPushMessage",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.OutgoingPushMessageList",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.PreKeyEntity",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.PreKeyEntity$ECPublicKeySerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.PreKeyState",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.PreKeyStatus",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.ProvisioningProtos$ProvisionEnvelope",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"body_", "allowUnsafeAccess":true}, 
+    {"name":"publicKey_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.ProvisioningProtos$ProvisionMessage",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"identityKeyPrivate_", "allowUnsafeAccess":true}, 
+    {"name":"identityKeyPublic_", "allowUnsafeAccess":true}, 
+    {"name":"number_", "allowUnsafeAccess":true}, 
+    {"name":"profileKey_", "allowUnsafeAccess":true}, 
+    {"name":"provisioningCode_", "allowUnsafeAccess":true}, 
+    {"name":"provisioningVersion_", "allowUnsafeAccess":true}, 
+    {"name":"readReceipts_", "allowUnsafeAccess":true}, 
+    {"name":"userAgent_", "allowUnsafeAccess":true}, 
+    {"name":"uuid_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.ProvisioningProtos$ProvisioningUuid",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"uuid_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.SendMessageResponse",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.SenderCertificate",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.SenderCertificate$ByteArrayDesieralizer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.SignalServiceProtos$AttachmentPointer",
+  "fields":[
+    {"name":"attachmentIdentifierCase_", "allowUnsafeAccess":true}, 
+    {"name":"attachmentIdentifier_", "allowUnsafeAccess":true}, 
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"blurHash_", "allowUnsafeAccess":true}, 
+    {"name":"caption_", "allowUnsafeAccess":true}, 
+    {"name":"cdnNumber_", "allowUnsafeAccess":true}, 
+    {"name":"contentType_", "allowUnsafeAccess":true}, 
+    {"name":"digest_", "allowUnsafeAccess":true}, 
+    {"name":"fileName_", "allowUnsafeAccess":true}, 
+    {"name":"flags_", "allowUnsafeAccess":true}, 
+    {"name":"height_", "allowUnsafeAccess":true}, 
+    {"name":"key_", "allowUnsafeAccess":true}, 
+    {"name":"size_", "allowUnsafeAccess":true}, 
+    {"name":"thumbnail_", "allowUnsafeAccess":true}, 
+    {"name":"uploadTimestamp_", "allowUnsafeAccess":true}, 
+    {"name":"width_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.SignalServiceProtos$Content",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"callMessage_", "allowUnsafeAccess":true}, 
+    {"name":"dataMessage_", "allowUnsafeAccess":true}, 
+    {"name":"nullMessage_", "allowUnsafeAccess":true}, 
+    {"name":"receiptMessage_", "allowUnsafeAccess":true}, 
+    {"name":"syncMessage_", "allowUnsafeAccess":true}, 
+    {"name":"typingMessage_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage",
+  "fields":[
+    {"name":"attachments_", "allowUnsafeAccess":true}, 
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"bodyRanges_", "allowUnsafeAccess":true}, 
+    {"name":"body_", "allowUnsafeAccess":true}, 
+    {"name":"contact_", "allowUnsafeAccess":true}, 
+    {"name":"delete_", "allowUnsafeAccess":true}, 
+    {"name":"expireTimer_", "allowUnsafeAccess":true}, 
+    {"name":"flags_", "allowUnsafeAccess":true}, 
+    {"name":"groupV2_", "allowUnsafeAccess":true}, 
+    {"name":"group_", "allowUnsafeAccess":true}, 
+    {"name":"isViewOnce_", "allowUnsafeAccess":true}, 
+    {"name":"preview_", "allowUnsafeAccess":true}, 
+    {"name":"profileKey_", "allowUnsafeAccess":true}, 
+    {"name":"quote_", "allowUnsafeAccess":true}, 
+    {"name":"reaction_", "allowUnsafeAccess":true}, 
+    {"name":"requiredProtocolVersion_", "allowUnsafeAccess":true}, 
+    {"name":"sticker_", "allowUnsafeAccess":true}, 
+    {"name":"timestamp_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$BodyRange",
+  "fields":[
+    {"name":"associatedValueCase_", "allowUnsafeAccess":true}, 
+    {"name":"associatedValue_", "allowUnsafeAccess":true}, 
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"length_", "allowUnsafeAccess":true}, 
+    {"name":"start_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Contact",
+  "fields":[
+    {"name":"address_", "allowUnsafeAccess":true}, 
+    {"name":"avatar_", "allowUnsafeAccess":true}, 
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"email_", "allowUnsafeAccess":true}, 
+    {"name":"name_", "allowUnsafeAccess":true}, 
+    {"name":"number_", "allowUnsafeAccess":true}, 
+    {"name":"organization_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Preview",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"date_", "allowUnsafeAccess":true}, 
+    {"name":"description_", "allowUnsafeAccess":true}, 
+    {"name":"image_", "allowUnsafeAccess":true}, 
+    {"name":"title_", "allowUnsafeAccess":true}, 
+    {"name":"url_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.SignalServiceProtos$GroupContextV2",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"groupChange_", "allowUnsafeAccess":true}, 
+    {"name":"masterKey_", "allowUnsafeAccess":true}, 
+    {"name":"revision_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.push.VerifyAccountResponse",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.whispersystems.signalservice.internal.util.JsonUtil$IdentityKeySerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.util.JsonUtil$UuidDeserializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.websocket.WebSocketProtos$WebSocketMessage",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"request_", "allowUnsafeAccess":true}, 
+    {"name":"response_", "allowUnsafeAccess":true}, 
+    {"name":"type_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.websocket.WebSocketProtos$WebSocketRequestMessage",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"body_", "allowUnsafeAccess":true}, 
+    {"name":"headers_", "allowUnsafeAccess":true}, 
+    {"name":"id_", "allowUnsafeAccess":true}, 
+    {"name":"path_", "allowUnsafeAccess":true}, 
+    {"name":"verb_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"org.whispersystems.signalservice.internal.websocket.WebSocketProtos$WebSocketResponseMessage",
+  "fields":[
+    {"name":"bitField0_", "allowUnsafeAccess":true}, 
+    {"name":"body_", "allowUnsafeAccess":true}, 
+    {"name":"headers_", "allowUnsafeAccess":true}, 
+    {"name":"id_", "allowUnsafeAccess":true}, 
+    {"name":"message_", "allowUnsafeAccess":true}, 
+    {"name":"status_", "allowUnsafeAccess":true}
+  ]
+},
+{
+  "name":"sun.misc.Unsafe",
+  "allDeclaredFields":true,
+  "methods":[
+    {"name":"arrayBaseOffset","parameterTypes":["java.lang.Class"] }, 
+    {"name":"arrayIndexScale","parameterTypes":["java.lang.Class"] }, 
+    {"name":"copyMemory","parameterTypes":["long","long","long"] }, 
+    {"name":"copyMemory","parameterTypes":["java.lang.Object","long","java.lang.Object","long","long"] }, 
+    {"name":"getBoolean","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getByte","parameterTypes":["long"] }, 
+    {"name":"getByte","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getDouble","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getFloat","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getInt","parameterTypes":["long"] }, 
+    {"name":"getInt","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getLong","parameterTypes":["long"] }, 
+    {"name":"getLong","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getObject","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"objectFieldOffset","parameterTypes":["java.lang.reflect.Field"] }, 
+    {"name":"putBoolean","parameterTypes":["java.lang.Object","long","boolean"] }, 
+    {"name":"putByte","parameterTypes":["long","byte"] }, 
+    {"name":"putByte","parameterTypes":["java.lang.Object","long","byte"] }, 
+    {"name":"putDouble","parameterTypes":["java.lang.Object","long","double"] }, 
+    {"name":"putFloat","parameterTypes":["java.lang.Object","long","float"] }, 
+    {"name":"putInt","parameterTypes":["long","int"] }, 
+    {"name":"putInt","parameterTypes":["java.lang.Object","long","int"] }, 
+    {"name":"putLong","parameterTypes":["long","long"] }, 
+    {"name":"putLong","parameterTypes":["java.lang.Object","long","long"] }, 
+    {"name":"putObject","parameterTypes":["java.lang.Object","long","java.lang.Object"] }
+  ]
+},
+{
+  "name":"sun.security.provider.DSA$SHA224withDSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.JavaKeyStore$DualFormatJKS",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.JavaKeyStore$JKS",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.NativePRNG",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA2$SHA224",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA2$SHA256",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA5$SHA384",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA5$SHA512",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SecureRandom",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.certpath.PKIXCertPathValidator",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSAKeyFactory$Legacy",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSAPSSSignature",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSASignature$SHA224withRSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSASignature$SHA256withRSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSASignature$SHA512withRSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.ssl.SSLContextImpl$TLSContext",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.x509.AuthorityKeyIdentifierExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.BasicConstraintsExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.CRLDistributionPointsExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.KeyUsageExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.SubjectAlternativeNameExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.SubjectKeyIdentifierExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+}
+]

--- a/graalvm-config-dir/resource-config.json
+++ b/graalvm-config-dir/resource-config.json
@@ -1,0 +1,11 @@
+{
+  "resources":{
+  "includes":[
+    {"pattern":"com/google/i18n/phonenumbers/data/.*"}, 
+    {"pattern":"libzkgroup.so"},
+    {"pattern":"org/asamk/signal/manager/ias.store"}, 
+    {"pattern":"org/asamk/signal/manager/whisper.store"}, 
+    {"pattern":"org/slf4j/impl/StaticLoggerBinder.class"}
+  ]},
+  "bundles":[{"name":"net.sourceforge.argparse4j.internal.ArgumentParserImpl"}]
+}


### PR DESCRIPTION
It is possible to build a native binary with GraalVM.

This could be helpful to run signal-cli without the need to install a JRE and startup times are faster on slow hardware like a raspberry pi.

I haven't tested dbus integration.
