### PR TITLE
Feature/aanno small gradle improvement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,9 @@ plugins {
     java
     application
     eclipse
+    `maven-publish`
     `check-lib-versions`
+    `java-library-distribution`
 }
 
 val projectVersion: String by project
@@ -39,6 +41,20 @@ configurations {
     }
 }
 
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
+    }
+}
+
+distributions {
+    main {
+        distributionBaseName.set("signal-cli")
+    }
+}
+
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
 }
@@ -53,6 +69,11 @@ tasks.withType<Jar> {
                 // Custom (non-standard) attribute
                 "Maven-Group" to project.group
         )
+    }
+    dependsOn("generatePomFileForMavenPublication")
+    into("META-INF/maven/${project.group}/${project.name}") {
+        from("$buildDir/publications/maven/pom-default.xml")
+        rename(".*", "pom.xml")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ tasks.withType<Jar> {
                 "Implementation-Title" to project.name,
                 "Implementation-Version" to project.version,
                 "Main-Class" to application.mainClass.get(),
-                "Automatic-Module-Name" to project.name,
+                "Automatic-Module-Name" to project.name.replace('-', '.'),
                 // Custom (non-standard) attribute
                 "Maven-Group" to project.group
         )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,11 @@ plugins {
     `check-lib-versions`
 }
 
-version = "0.7.4"
-group = "org.asamk.signal"
+val projectVersion: String by project
+val mavenGroup: String by project
+
+version = projectVersion
+group = mavenGroup
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 version = "0.7.4"
+group = "org.asamk.signal"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
@@ -44,7 +45,10 @@ tasks.withType<Jar> {
         attributes(
                 "Implementation-Title" to project.name,
                 "Implementation-Version" to project.version,
-                "Main-Class" to application.mainClass.get()
+                "Main-Class" to application.mainClass.get(),
+                "Automatic-Module-Name" to project.name,
+                // Custom (non-standard) attribute
+                "Maven-Group" to project.group
         )
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+projectVersion=0.7.4
+mavenGroup=org.asamk.signal

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -38,7 +38,7 @@ tasks.withType<Jar> {
             "Implementation-Title" to project.name,
             "Implementation-Version" to project.version,
             // use a more meaningful name than 'lib'
-            "Automatic-Module-Name" to "signal-lib",
+            "Automatic-Module-Name" to "signal.lib",
             // Custom (non-standard) attribute
             "Maven-Group" to project.group
         )

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -3,6 +3,12 @@ plugins {
     `check-lib-versions`
 }
 
+val projectVersion: String by project
+val mavenGroup: String by project
+
+version = projectVersion
+group = mavenGroup
+
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `java-library`
     `check-lib-versions`
+    `maven-publish`
 }
 
 val projectVersion: String by project
@@ -32,6 +33,14 @@ configurations {
     }
 }
 
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
+    }
+}
+
 tasks.withType<Jar> {
     manifest {
         attributes(
@@ -42,6 +51,11 @@ tasks.withType<Jar> {
             // Custom (non-standard) attribute
             "Maven-Group" to project.group
         )
+    }
+    dependsOn("generatePomFileForMavenPublication")
+    into("META-INF/maven/${project.group}/${project.name}") {
+        from("$buildDir/publications/maven/pom-default.xml")
+        rename(".*", "pom.xml")
     }
 }
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -26,6 +26,19 @@ configurations {
     }
 }
 
+tasks.withType<Jar> {
+    manifest {
+        attributes(
+            "Implementation-Title" to project.name,
+            "Implementation-Version" to project.version,
+            // use a more meaningful name than 'lib'
+            "Automatic-Module-Name" to "signal-lib",
+            // Custom (non-standard) attribute
+            "Maven-Group" to project.group
+        )
+    }
+}
+
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
 }


### PR DESCRIPTION
Dear AsamK,

here are some gradle build improvements that I found useful when using your great signal-cli:

1. Provide a (maven) group for `signal-cli` and `lib` from `gradle.properties`
2. Provide the version for `signal-cli` and `lib` from `gradle.properties`
3. Pack a generated `pom.xml` with both jars (the way it would be if the jars are generated with maven). This would help dependency management if the jars are used in other projects.
4. Provide a distribution zip and tar (with all dependencies packed). This will simply the use of `signal-cli` as user.
5. Add a 'Automatic-Module-Name' entry to the manifest. This is helpful if the jars are used as dependencies in a Java 11 module-system project.
6. Add a 'Maven-Group' entry to the manifest.

Perhaps you find some of this suggestions useful.

Kind regards,

aanno