### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can [build signal-cli](#building) yourself, or use the [provided binary file
 
 System requirements:
 - at least Java Runtime Environment (JRE) 11
-- native libraries: libzkgroup, libsignal-client
+- native libraries: libzkgroup, libsignal-client  
   Those are bundled for x86_64 Linux, for other systems/architectures see: [Provide native lib for libsignal](https://github.com/AsamK/signal-cli/wiki/Provide-native-lib-for-libsignal)
 
 ### Install system-wide on Linux


### PR DESCRIPTION
By adding two spaces at the end of a line, we force the Markdown renderer to insert a new line.