### PR TITLE
add missing reflection declarations for graalvm

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     `check-lib-versions`
 }
 
-version = "0.8.1"
+version = "0.8.2"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/graalvm-config-dir/reflect-config.json
+++ b/graalvm-config-dir/reflect-config.json
@@ -331,6 +331,18 @@
   "allDeclaredConstructors":true
 },
 {
+  "name": "org.asamk.signal.json.JsonGroupInfo",
+  "allDeclaredFields": true,
+  "allDeclaredMethods": true,
+  "allDeclaredConstructors": true
+},
+{
+  "name": "org.asamk.signal.json.JsonSyncMessage",
+  "allDeclaredFields": true,
+  "allDeclaredMethods": true,
+  "allDeclaredConstructors": true
+},
+{
   "name":"org.asamk.signal.json.JsonMessageEnvelope",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,

--- a/graalvm-config-dir/reflect-config.json
+++ b/graalvm-config-dir/reflect-config.json
@@ -319,6 +319,42 @@
   "allDeclaredConstructors":true
 },
 {
+  "name":"org.asamk.signal.json.JsonCallMessage",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.json.JsonContactAddress",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.json.JsonContactAvatar",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.json.JsonContactEmail",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.json.JsonContactName",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.json.JsonContactPhone",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
   "name":"org.asamk.signal.json.JsonDataMessage",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
@@ -332,18 +368,30 @@
 },
 {
   "name": "org.asamk.signal.json.JsonGroupInfo",
-  "allDeclaredFields": true,
-  "allDeclaredMethods": true,
-  "allDeclaredConstructors": true
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
 },
 {
-  "name": "org.asamk.signal.json.JsonSyncMessage",
-  "allDeclaredFields": true,
-  "allDeclaredMethods": true,
-  "allDeclaredConstructors": true
+  "name": "org.asamk.signal.json.JsonMention",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
 },
 {
   "name":"org.asamk.signal.json.JsonMessageEnvelope",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"org.asamk.signal.json.JsonQuote",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "org.asamk.signal.json.JsonQuotedAttachment",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true
@@ -361,13 +409,37 @@
   "allDeclaredConstructors":true
 },
 {
-  "name":"org.asamk.signal.json.JsonRemoteDelete",
+  "name": "org.asamk.signal.json.JsonRemoteDelete",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true
 },
 {
-  "name":"org.asamk.signal.json.JsonSticker",
+  "name": "org.asamk.signal.json.JsonSharedContact",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "org.asamk.signal.json.JsonSticker",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "org.asamk.signal.json.JsonSyncDataMessage",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "org.asamk.signal.json.JsonSyncMessage",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "org.asamk.signal.json.JsonSyncReadMessage",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true


### PR DESCRIPTION
This fixes https://github.com/AsamK/signal-cli/issues/572 and https://github.com/bbernhard/signal-cli-rest-api/issues/103. Apparently, I did not build it correctly before which made me believe that the fix here did not work. I tried it again and it worked.

## Output before fix

```
!?master ~/Development/signal-bot/signal-cli> ./build/native-image/signal-cli -o json -u USER receive
{"envelope":{"source":"USER","sourceDevice":1,"timestamp":TS,"syncMessage"WARN ErrorUtils - If you use an Oracle JRE please check if you have unlimited strength crypto enabled, see README
Exception in thread "main" java.lang.AssertionError: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.asamk.signal.json.JsonSyncMessage and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: java.util.HashMap["envelope"]->org.asamk.signal.json.JsonMessageEnvelope["syncMessage"])
	at org.asamk.signal.JsonWriter.write(JsonWriter.java:35)
	at org.asamk.signal.JsonReceiveMessageHandler.handleMessage(JsonReceiveMessageHandler.java:35)
	at org.asamk.signal.manager.Manager.receiveMessages(Manager.java:1768)
	at org.asamk.signal.commands.ReceiveCommand.handleCommand(ReceiveCommand.java:165)
	at org.asamk.signal.App.handleLocalCommand(App.java:203)
	at org.asamk.signal.App.init(App.java:163)
	at org.asamk.signal.Main.main(Main.java:49)
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.asamk.signal.json.JsonSyncMessage and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: java.util.HashMap["envelope"]->org.asamk.signal.json.JsonMessageEnvelope["syncMessage"])
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1191)
	at com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:313)
	at com.fasterxml.jackson.databind.ser.impl.UnknownSerializer.failForEmpty(UnknownSerializer.java:71)
	at com.fasterxml.jackson.databind.ser.impl.UnknownSerializer.serialize(UnknownSerializer.java:33)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:727)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:719)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:155)
	at com.fasterxml.jackson.databind.ser.std.MapSerializer.serializeFields(MapSerializer.java:722)
	at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:643)
	at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:33)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
	at com.fasterxml.jackson.databind.ObjectMapper._configAndWriteValue(ObjectMapper.java:3906)
	at com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:3202)
	at org.asamk.signal.JsonWriter.write(JsonWriter.java:32)
	... 6 more
```

## Output after fix
```
(base) !?master ~/Development/signal-bot/signal-cli> ./build/native-image/signal-cli -o json -u USER receive
{"envelope":{"source":"USER","sourceDevice":1,"timestamp":TS,"syncMessage":{"sentMessage":{"timestamp":TS,"message":"Djdhd","expiresInSeconds":0,"viewOnce":false,"mentions":[],"attachments":[],"contacts":[],"groupInfo":{"groupId":"GROUPID","type":"DELIVER"}}}}}
```