### PR TITLE
Fix sendReaction to group

### DIFF
--- a/src/main/java/org/asamk/signal/commands/SendReactionCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendReactionCommand.java
@@ -67,7 +67,7 @@ public class SendReactionCommand implements LocalCommand {
         final Pair<Long, List<SendMessageResult>> results;
 
         GroupId groupId = null;
-        if (groupId != null) {
+        if (groupIdString != null) {
             try {
                 groupId = Util.decodeGroupId(groupIdString);
             } catch (GroupIdFormatException e) {


### PR DESCRIPTION
sendReaction to group couldn't work for obvious reasons (see rows 69 and 70 in SendReactionCommand.java).
Fixes #577.
Verified that it works by building and testing.