### PR TITLE
dbus implementation of sendReaction command

### DIFF
--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -21,6 +21,14 @@ public interface Signal extends DBusInterface {
             String message, List<String> attachments, List<String> recipients
     ) throws Error.AttachmentInvalid, Error.Failure, Error.InvalidNumber, Error.UntrustedIdentity;
 
+    long sendMessageReaction(
+            String emoji, boolean remove, String targetAuthor, long targetSentTimestamp, String recipient
+    ) throws Error.InvalidNumber, Error.Failure;
+
+    long sendMessageReaction(
+            String emoji, boolean remove, String targetAuthor, long targetSentTimestamp, List<String> recipients
+    ) throws Error.InvalidNumber, Error.Failure;
+
     long sendNoteToSelfMessage(
             String message, List<String> attachments
     ) throws Error.AttachmentInvalid, Error.Failure;
@@ -30,6 +38,10 @@ public interface Signal extends DBusInterface {
     long sendGroupMessage(
             String message, List<String> attachments, byte[] groupId
     ) throws Error.GroupNotFound, Error.Failure, Error.AttachmentInvalid;
+
+    long sendGroupMessageReaction(
+            String emoji, boolean remove, String targetAuthor, long targetSentTimestamp, byte[] groupId
+    ) throws Error.GroupNotFound, Error.Failure, Error.InvalidNumber;
 
     String getContactName(String number) throws Error.InvalidNumber;
 

--- a/src/main/java/org/asamk/signal/commands/SendCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendCommand.java
@@ -98,7 +98,7 @@ public class SendCommand implements DbusCommand {
             try {
                 groupId = Util.decodeGroupId(groupIdString).serialize();
             } catch (GroupIdFormatException e) {
-                throw new UserErrorException("Invalid group id:" + e.getMessage());
+                throw new UserErrorException("Invalid group id: " + e.getMessage());
             }
 
             try {

--- a/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
@@ -104,6 +104,30 @@ public class DbusSignalImpl implements Signal {
     }
 
     @Override
+    public long sendMessageReaction(
+            final String emoji, final boolean remove, final String targetAuthor, final long targetSentTimestamp, final String recipient
+    ) {
+        var recipients = new ArrayList<String>(1);
+        recipients.add(recipient);
+        return sendMessageReaction(emoji, remove, targetAuthor, targetSentTimestamp, recipients);
+    }
+
+    @Override
+    public long sendMessageReaction(
+            final String emoji, final boolean remove, final String targetAuthor, final long targetSentTimestamp, final List<String> recipients
+    ) {
+        try {
+            final var results = m.sendMessageReaction(emoji, remove, targetAuthor, targetSentTimestamp, recipients);
+            checkSendMessageResults(results.first(), results.second());
+            return results.first();
+        } catch (InvalidNumberException e) {
+            throw new Error.InvalidNumber(e.getMessage());
+        } catch (IOException e) {
+            throw new Error.Failure(e.getMessage());
+        }
+    }
+
+    @Override
     public long sendNoteToSelfMessage(
             final String message, final List<String> attachments
     ) throws Error.AttachmentInvalid, Error.Failure, Error.UntrustedIdentity {
@@ -142,6 +166,23 @@ public class DbusSignalImpl implements Signal {
             throw new Error.GroupNotFound(e.getMessage());
         } catch (AttachmentInvalidException e) {
             throw new Error.AttachmentInvalid(e.getMessage());
+        }
+    }
+
+    @Override
+    public long sendGroupMessageReaction(
+            final String emoji, final boolean remove, final String targetAuthor, final long targetSentTimestamp, final byte[] groupId
+    ) {
+        try {
+            final var results = m.sendGroupMessageReaction(emoji, remove, targetAuthor, targetSentTimestamp, GroupId.unknownVersion(groupId));
+            checkSendMessageResults(results.first(), results.second());
+            return results.first();
+        } catch (IOException e) {
+            throw new Error.Failure(e.getMessage());
+        } catch (InvalidNumberException e) {
+            throw new Error.InvalidNumber(e.getMessage());
+        } catch (GroupNotFoundException | NotAGroupMemberException e) {
+            throw new Error.GroupNotFound(e.getMessage());
         }
     }
 


### PR DESCRIPTION
This implements dbus support for sendReaction command.
Fixes #319 
Usage:
```
signal-cli --dbus-system -u USERNAME sendReaction -t TARGET_TIMESTAMP -a TARGET_AUTHOR -e EMOJI [-r] <recipient [recipient ...] | -g GROUP>
```

Build passed, tested in dbus & non-dbus mode.