### PR TITLE
Send remote delete

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/Manager.java
+++ b/lib/src/main/java/org/asamk/signal/manager/Manager.java
@@ -992,6 +992,22 @@ public class Manager implements Closeable {
         return sendSelfMessage(messageBuilder);
     }
 
+    public Pair<Long, List<SendMessageResult>> remoteDelete(
+            long targetSentTimestamp, List<String> recipients
+    ) throws IOException, InvalidNumberException {
+        var delete = new SignalServiceDataMessage.RemoteDelete(targetSentTimestamp);
+        final var messageBuilder = SignalServiceDataMessage.newBuilder().withRemoteDelete(delete);
+        return sendMessage(messageBuilder, getSignalServiceAddresses(recipients));
+    }
+
+    public Pair<Long, List<SendMessageResult>> remoteGroupDelete(
+            long targetSentTimestamp, GroupId groupId
+    ) throws IOException, NotAGroupMemberException, GroupNotFoundException {
+        var delete = new SignalServiceDataMessage.RemoteDelete(targetSentTimestamp);
+        final var messageBuilder = SignalServiceDataMessage.newBuilder().withRemoteDelete(delete);
+        return sendGroupMessage(messageBuilder, groupId);
+    }
+
     public Pair<Long, List<SendMessageResult>> sendMessageReaction(
             String emoji, boolean remove, String targetAuthor, long targetSentTimestamp, List<String> recipients
     ) throws IOException, InvalidNumberException {

--- a/lib/src/main/java/org/asamk/signal/manager/Manager.java
+++ b/lib/src/main/java/org/asamk/signal/manager/Manager.java
@@ -992,7 +992,7 @@ public class Manager implements Closeable {
         return sendSelfMessage(messageBuilder);
     }
 
-    public Pair<Long, List<SendMessageResult>> remoteDelete(
+    public Pair<Long, List<SendMessageResult>> sendRemoteDeleteMessage(
             long targetSentTimestamp, List<String> recipients
     ) throws IOException, InvalidNumberException {
         var delete = new SignalServiceDataMessage.RemoteDelete(targetSentTimestamp);
@@ -1000,7 +1000,7 @@ public class Manager implements Closeable {
         return sendMessage(messageBuilder, getSignalServiceAddresses(recipients));
     }
 
-    public Pair<Long, List<SendMessageResult>> remoteGroupDelete(
+    public Pair<Long, List<SendMessageResult>> sendGroupRemoteDeleteMessage(
             long targetSentTimestamp, GroupId groupId
     ) throws IOException, NotAGroupMemberException, GroupNotFoundException {
         var delete = new SignalServiceDataMessage.RemoteDelete(targetSentTimestamp);

--- a/man/signal-cli-dbus.5.adoc
+++ b/man/signal-cli-dbus.5.adoc
@@ -98,7 +98,7 @@ sendEndSessionMessage(recipients<as>) -> <>::
 
 Exceptions: Failure, InvalidNumber, UntrustedIdentity
 
-sendGroupMessage(message<s>, attachments<as>, groupId<a>) -> timestamp<x>::
+sendGroupMessage(message<s>, attachments<as>, groupId<ay>) -> timestamp<x>::
 * message     : Text to send (can be UTF8)
 * attachments : String array of filenames to send as attachments (passed as filename, so need to be readable by the user signal-cli is running under)
 * groupId     : Byte array representing the internal group identifier
@@ -113,7 +113,7 @@ sendNoteToSelfMessage(message<s>, attachments<as>) -> timestamp<x>::
 
 Exceptions: Failure, AttachmentInvalid
 
-sendMessage(message<s>, attachments<as>, recipient<s) -> timestamp<x>::
+sendMessage(message<s>, attachments<as>, recipient<s>) -> timestamp<x>::
 sendMessage(message<s>, attachments<as>, recipients<as>) -> timestamp<x>::
 * message     : Text to send (can be UTF8)
 * attachments : String array of filenames to send as attachments (passed as filename, so need to be readable by the user signal-cli is running under)
@@ -123,7 +123,49 @@ sendMessage(message<s>, attachments<as>, recipients<as>) -> timestamp<x>::
 
 Depending on the type of the recipient field this sends a message to one or multiple recipients.
 
-Expections: AttachmentInvalid, Failure, InvalidNumber, UntrustedIdentity
+Exceptions: AttachmentInvalid, Failure, InvalidNumber, UntrustedIdentity
+
+sendGroupMessageReaction(emoji<s>, remove<b>, targetAuthor<s>, targetSentTimestamp<x>, groupId<ay>) -> timestamp<x>::
+* emoji               : Unicode grapheme cluster of the emoji
+* remove              : Boolean, whether a previously sent reaction (emoji) should be removed
+* targetAuthor        : String with the phone number of the author of the message to which to react
+* targetSentTimestamp : Long representing timestamp of the message to which to react
+* groupId             : Byte array with base64 encoded group identifier
+* timestamp           : Long, can be used to identify the corresponding signal reply
+
+Exceptions: Failure, InvalidNumber, GroupNotFound
+
+sendMessageReaction(emoji<s>, remove<b>, targetAuthor<s>, targetSentTimestamp<x>, recipient<s>) -> timestamp<x>::
+sendMessageReaction(emoji<s>, remove<b>, targetAuthor<s>, targetSentTimestamp<x>, recipients<as>) -> timestamp<x>::
+* emoji               : Unicode grapheme cluster of the emoji
+* remove              : Boolean, whether a previously sent reaction (emoji) should be removed
+* targetAuthor        : String with the phone number of the author of the message to which to react
+* targetSentTimestamp : Long representing timestamp of the message to which to react
+* recipient           : String with the phone number of a single recipient
+* recipients          : Array of strings with phone numbers, should there be more recipients
+* timestamp           : Long, can be used to identify the corresponding signal reply
+
+Depending on the type of the recipient(s) field this sends a reaction to one or multiple recipients.
+
+Exceptions: Failure, InvalidNumber
+
+remoteGroupDelete(targetSentTimestamp<x>, groupId<ay>) -> timestamp<x>::
+* targetSentTimestamp : Long representing timestamp of the message to delete
+* groupId             : Byte array with base64 encoded group identifier
+* timestamp           : Long, can be used to identify the corresponding signal reply
+
+Exceptions: Failure, GroupNotFound
+
+remoteDelete(targetSentTimestamp<x>, recipient<s>) -> timestamp<x>::
+remoteDelete(targetSentTimestamp<x>, recipients<as>) -> timestamp<x>::
+* targetSentTimestamp : Long representing timestamp of the message to delete
+* recipient           : String with the phone number of a single recipient
+* recipients          : Array of strings with phone numbers, should there be more recipients
+* timestamp           : Long, can be used to identify the corresponding signal reply
+
+Depending on the type of the recipient(s) field this deletes a message with one or multiple recipients.
+
+Exceptions: Failure, InvalidNumber
 
 getContactName(number<s>) -> name<s>::
 * number  : Phone number

--- a/man/signal-cli-dbus.5.adoc
+++ b/man/signal-cli-dbus.5.adoc
@@ -149,15 +149,15 @@ Depending on the type of the recipient(s) field this sends a reaction to one or 
 
 Exceptions: Failure, InvalidNumber
 
-remoteGroupDelete(targetSentTimestamp<x>, groupId<ay>) -> timestamp<x>::
+sendGroupRemoteDeleteMessage(targetSentTimestamp<x>, groupId<ay>) -> timestamp<x>::
 * targetSentTimestamp : Long representing timestamp of the message to delete
 * groupId             : Byte array with base64 encoded group identifier
 * timestamp           : Long, can be used to identify the corresponding signal reply
 
 Exceptions: Failure, GroupNotFound
 
-remoteDelete(targetSentTimestamp<x>, recipient<s>) -> timestamp<x>::
-remoteDelete(targetSentTimestamp<x>, recipients<as>) -> timestamp<x>::
+sendRemoteDeleteMessage(targetSentTimestamp<x>, recipient<s>) -> timestamp<x>::
+sendRemoteDeleteMessage(targetSentTimestamp<x>, recipients<as>) -> timestamp<x>::
 * targetSentTimestamp : Long representing timestamp of the message to delete
 * recipient           : String with the phone number of a single recipient
 * recipients          : Array of strings with phone numbers, should there be more recipients

--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -193,6 +193,19 @@ Specify the timestamp of the message to which to react.
 *-r*, *--remove*::
 Remove a reaction.
 
+=== remoteDelete
+
+Remotely delete a previously sent message.
+
+RECIPIENT::
+Specify the recipients’ phone number.
+
+*-g* GROUP, *--group* GROUP::
+Specify the recipient group ID in base64 encoding.
+
+*-t* TIMESTAMP, *--target-timestamp* TIMESTAMP::
+Specify the timestamp of the message to delete.
+
 === receive
 
 Query the server for new messages.

--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -21,6 +21,14 @@ public interface Signal extends DBusInterface {
             String message, List<String> attachments, List<String> recipients
     ) throws Error.AttachmentInvalid, Error.Failure, Error.InvalidNumber, Error.UntrustedIdentity;
 
+    long remoteDelete(
+            long targetSentTimestamp, List<String> recipients
+    ) throws Error.Failure, Error.InvalidNumber;
+
+    long remoteGroupDelete(
+            long targetSentTimestamp, byte[] groupId
+    ) throws Error.Failure, Error.GroupNotFound;
+
     long sendMessageReaction(
             String emoji, boolean remove, String targetAuthor, long targetSentTimestamp, String recipient
     ) throws Error.InvalidNumber, Error.Failure;

--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -21,15 +21,15 @@ public interface Signal extends DBusInterface {
             String message, List<String> attachments, List<String> recipients
     ) throws Error.AttachmentInvalid, Error.Failure, Error.InvalidNumber, Error.UntrustedIdentity;
 
-    long remoteDelete(
+    long sendRemoteDeleteMessage(
             long targetSentTimestamp, String recipient
     ) throws Error.Failure, Error.InvalidNumber;
 
-    long remoteDelete(
+    long sendRemoteDeleteMessage(
             long targetSentTimestamp, List<String> recipients
     ) throws Error.Failure, Error.InvalidNumber;
 
-    long remoteGroupDelete(
+    long sendGroupRemoteDeleteMessage(
             long targetSentTimestamp, byte[] groupId
     ) throws Error.Failure, Error.GroupNotFound;
 

--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -22,6 +22,10 @@ public interface Signal extends DBusInterface {
     ) throws Error.AttachmentInvalid, Error.Failure, Error.InvalidNumber, Error.UntrustedIdentity;
 
     long remoteDelete(
+            long targetSentTimestamp, String recipient
+    ) throws Error.Failure, Error.InvalidNumber;
+
+    long remoteDelete(
             long targetSentTimestamp, List<String> recipients
     ) throws Error.Failure, Error.InvalidNumber;
 

--- a/src/main/java/org/asamk/signal/commands/Commands.java
+++ b/src/main/java/org/asamk/signal/commands/Commands.java
@@ -22,20 +22,21 @@ public class Commands {
         addCommand("receive", new ReceiveCommand());
         addCommand("register", new RegisterCommand());
         addCommand("removeDevice", new RemoveDeviceCommand());
+        addCommand("remoteDelete", new RemoteDeleteCommand());
         addCommand("removePin", new RemovePinCommand());
         addCommand("send", new SendCommand());
-        addCommand("sendReaction", new SendReactionCommand());
         addCommand("sendContacts", new SendContactsCommand());
-        addCommand("updateContact", new UpdateContactCommand());
+        addCommand("sendReaction", new SendReactionCommand());
         addCommand("setPin", new SetPinCommand());
         addCommand("trust", new TrustCommand());
         addCommand("unblock", new UnblockCommand());
         addCommand("unregister", new UnregisterCommand());
         addCommand("updateAccount", new UpdateAccountCommand());
+        addCommand("updateContact", new UpdateContactCommand());
         addCommand("updateGroup", new UpdateGroupCommand());
         addCommand("updateProfile", new UpdateProfileCommand());
-        addCommand("verify", new VerifyCommand());
         addCommand("uploadStickerPack", new UploadStickerPackCommand());
+        addCommand("verify", new VerifyCommand());
     }
 
     public static Map<String, Command> getCommands() {

--- a/src/main/java/org/asamk/signal/commands/RemoteDeleteCommand.java
+++ b/src/main/java/org/asamk/signal/commands/RemoteDeleteCommand.java
@@ -1,0 +1,85 @@
+package org.asamk.signal.commands;
+
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+
+import org.asamk.Signal;
+import org.asamk.signal.PlainTextWriterImpl;
+import org.asamk.signal.commands.exceptions.CommandException;
+import org.asamk.signal.commands.exceptions.UnexpectedErrorException;
+import org.asamk.signal.commands.exceptions.UserErrorException;
+import org.asamk.signal.manager.groups.GroupIdFormatException;
+import org.asamk.signal.util.Util;
+import org.freedesktop.dbus.errors.UnknownObject;
+import org.freedesktop.dbus.exceptions.DBusExecutionException;
+
+import java.util.List;
+
+import static org.asamk.signal.util.ErrorUtils.handleAssertionError;
+
+public class RemoteDeleteCommand implements DbusCommand {
+
+    @Override
+    public void attachToSubparser(final Subparser subparser) {
+        subparser.help("Remotely delete a previously sent message.");
+        subparser.addArgument("-t", "--target-timestamp")
+                .required(true)
+                .type(long.class)
+                .help("Specify the timestamp of the message to delete.");
+        var mut = subparser.addMutuallyExclusiveGroup().required(true);
+        mut.addArgument("-g", "--group").help("Specify the recipient group ID.");
+        mut.addArgument("recipient").help("Specify the recipients' phone number.").nargs("*");
+    }
+
+    @Override
+    public void handleCommand(final Namespace ns, final Signal signal) throws CommandException {
+        final List<String> recipients = ns.getList("recipient");
+        final var groupIdString = ns.getString("group");
+
+        // Possibly unnecessary (see above — recipient(s) or group is required),
+        // but just for case...
+        final var noRecipients = recipients == null || recipients.isEmpty();
+        if (noRecipients && groupIdString == null) {
+            throw new UserErrorException("No recipients given");
+        }
+        // Possibly unnecessary (see above — recipient(s) and group are mutually exclusive),
+        // but just for case...
+        if (!noRecipients && groupIdString != null) {
+            throw new UserErrorException("You cannot specify recipients by phone number and groups at the same time");
+        }
+
+        final long targetTimestamp = ns.getLong("target_timestamp");
+
+        final var writer = new PlainTextWriterImpl(System.out);
+
+        byte[] groupId = null;
+        if (groupIdString != null) {
+            try {
+                groupId = Util.decodeGroupId(groupIdString).serialize();
+            } catch (GroupIdFormatException e) {
+                throw new UserErrorException("Invalid group id: " + e.getMessage());
+            }
+        }
+
+        try {
+            long timestamp;
+            if (groupId != null) {
+                timestamp = signal.remoteGroupDelete(targetTimestamp, groupId);
+            } else {
+                timestamp = signal.remoteDelete(targetTimestamp, recipients);
+            }
+            writer.println("{}", timestamp);
+        } catch (AssertionError e) {
+            handleAssertionError(e);
+            throw e;
+        } catch (UnknownObject e) {
+            throw new UserErrorException("Failed to find dbus object, maybe missing the -u flag: " + e.getMessage());
+        } catch (Signal.Error.InvalidNumber e) {
+            throw new UserErrorException("Invalid number: " + e.getMessage());
+        } catch (Signal.Error.GroupNotFound e) {
+            throw new UserErrorException("Failed to send to group: " + e.getMessage());
+        } catch (DBusExecutionException e) {
+            throw new UnexpectedErrorException("Failed to send message: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/asamk/signal/commands/RemoteDeleteCommand.java
+++ b/src/main/java/org/asamk/signal/commands/RemoteDeleteCommand.java
@@ -26,9 +26,14 @@ public class RemoteDeleteCommand implements DbusCommand {
                 .required(true)
                 .type(long.class)
                 .help("Specify the timestamp of the message to delete.");
-        var mut = subparser.addMutuallyExclusiveGroup();
-        mut.addArgument("-g", "--group").help("Specify the recipient group ID.");
-        mut.addArgument("recipient").help("Specify the recipients' phone number.").nargs("*");
+        var mut = subparser.addMutuallyExclusiveGroup()
+                .required(true);
+        mut.addArgument("-g", "--group")
+                .required(false)
+                .help("Specify the recipient group ID.");
+        mut.addArgument("recipient")
+                .required(false)
+                .help("Specify the recipients' phone number.").nargs("*");
     }
 
     @Override
@@ -36,6 +41,8 @@ public class RemoteDeleteCommand implements DbusCommand {
         final List<String> recipients = ns.getList("recipient");
         final var groupIdString = ns.getString("group");
 
+        // Possibly unnecessary (see above — recipient(s) or group is required),
+        // but just for case...
         final var noRecipients = recipients == null || recipients.isEmpty();
         if (noRecipients && groupIdString == null) {
             throw new UserErrorException("No recipients given");

--- a/src/main/java/org/asamk/signal/commands/RemoteDeleteCommand.java
+++ b/src/main/java/org/asamk/signal/commands/RemoteDeleteCommand.java
@@ -26,7 +26,7 @@ public class RemoteDeleteCommand implements DbusCommand {
                 .required(true)
                 .type(long.class)
                 .help("Specify the timestamp of the message to delete.");
-        var mut = subparser.addMutuallyExclusiveGroup().required(true);
+        var mut = subparser.addMutuallyExclusiveGroup();
         mut.addArgument("-g", "--group").help("Specify the recipient group ID.");
         mut.addArgument("recipient").help("Specify the recipients' phone number.").nargs("*");
     }
@@ -36,8 +36,6 @@ public class RemoteDeleteCommand implements DbusCommand {
         final List<String> recipients = ns.getList("recipient");
         final var groupIdString = ns.getString("group");
 
-        // Possibly unnecessary (see above — recipient(s) or group is required),
-        // but just for case...
         final var noRecipients = recipients == null || recipients.isEmpty();
         if (noRecipients && groupIdString == null) {
             throw new UserErrorException("No recipients given");

--- a/src/main/java/org/asamk/signal/commands/RemoteDeleteCommand.java
+++ b/src/main/java/org/asamk/signal/commands/RemoteDeleteCommand.java
@@ -61,9 +61,9 @@ public class RemoteDeleteCommand implements DbusCommand {
         try {
             long timestamp;
             if (groupId != null) {
-                timestamp = signal.remoteGroupDelete(targetTimestamp, groupId);
+                timestamp = signal.sendGroupRemoteDeleteMessage(targetTimestamp, groupId);
             } else {
-                timestamp = signal.remoteDelete(targetTimestamp, recipients);
+                timestamp = signal.sendRemoteDeleteMessage(targetTimestamp, recipients);
             }
             writer.println("{}", timestamp);
         } catch (AssertionError e) {

--- a/src/main/java/org/asamk/signal/commands/RemoteDeleteCommand.java
+++ b/src/main/java/org/asamk/signal/commands/RemoteDeleteCommand.java
@@ -26,13 +26,9 @@ public class RemoteDeleteCommand implements DbusCommand {
                 .required(true)
                 .type(long.class)
                 .help("Specify the timestamp of the message to delete.");
-        var mut = subparser.addMutuallyExclusiveGroup()
-                .required(true);
-        mut.addArgument("-g", "--group")
-                .required(false)
+        subparser.addArgument("-g", "--group")
                 .help("Specify the recipient group ID.");
-        mut.addArgument("recipient")
-                .required(false)
+        subparser.addArgument("recipient")
                 .help("Specify the recipients' phone number.").nargs("*");
     }
 
@@ -41,14 +37,10 @@ public class RemoteDeleteCommand implements DbusCommand {
         final List<String> recipients = ns.getList("recipient");
         final var groupIdString = ns.getString("group");
 
-        // Possibly unnecessary (see above — recipient(s) or group is required),
-        // but just for case...
         final var noRecipients = recipients == null || recipients.isEmpty();
         if (noRecipients && groupIdString == null) {
             throw new UserErrorException("No recipients given");
         }
-        // Possibly unnecessary (see above — recipient(s) and group are mutually exclusive),
-        // but just for case...
         if (!noRecipients && groupIdString != null) {
             throw new UserErrorException("You cannot specify recipients by phone number and groups at the same time");
         }

--- a/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
@@ -104,20 +104,20 @@ public class DbusSignalImpl implements Signal {
     }
 
     @Override
-    public long remoteDelete(
+    public long sendRemoteDeleteMessage(
             final long targetSentTimestamp, final String recipient
     ) {
         var recipients = new ArrayList<String>(1);
         recipients.add(recipient);
-        return remoteDelete(targetSentTimestamp, recipients);
+        return sendRemoteDeleteMessage(targetSentTimestamp, recipients);
     }
 
     @Override
-    public long remoteDelete(
+    public long sendRemoteDeleteMessage(
             final long targetSentTimestamp, final List<String> recipients
     ) {
         try {
-            final var results = m.remoteDelete(targetSentTimestamp, recipients);
+            final var results = m.sendRemoteDeleteMessage(targetSentTimestamp, recipients);
             checkSendMessageResults(results.first(), results.second());
             return results.first();
         } catch (IOException e) {
@@ -128,11 +128,11 @@ public class DbusSignalImpl implements Signal {
     }
 
     @Override
-    public long remoteGroupDelete(
+    public long sendGroupRemoteDeleteMessage(
             final long targetSentTimestamp, final byte[] groupId
     ) {
         try {
-            final var results = m.remoteGroupDelete(targetSentTimestamp, GroupId.unknownVersion(groupId));
+            final var results = m.sendGroupRemoteDeleteMessage(targetSentTimestamp, GroupId.unknownVersion(groupId));
             checkSendMessageResults(results.first(), results.second());
             return results.first();
         } catch (IOException e) {

--- a/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
@@ -105,6 +105,15 @@ public class DbusSignalImpl implements Signal {
 
     @Override
     public long remoteDelete(
+            final long targetSentTimestamp, final String recipient
+    ) {
+        var recipients = new ArrayList<String>(1);
+        recipients.add(recipient);
+        return remoteDelete(targetSentTimestamp, recipients);
+    }
+
+    @Override
+    public long remoteDelete(
             final long targetSentTimestamp, final List<String> recipients
     ) {
         try {

--- a/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
@@ -104,6 +104,36 @@ public class DbusSignalImpl implements Signal {
     }
 
     @Override
+    public long remoteDelete(
+            final long targetSentTimestamp, final List<String> recipients
+    ) {
+        try {
+            final var results = m.remoteDelete(targetSentTimestamp, recipients);
+            checkSendMessageResults(results.first(), results.second());
+            return results.first();
+        } catch (IOException e) {
+            throw new Error.Failure(e.getMessage());
+        } catch (InvalidNumberException e) {
+            throw new Error.InvalidNumber(e.getMessage());
+        }
+    }
+
+    @Override
+    public long remoteGroupDelete(
+            final long targetSentTimestamp, final byte[] groupId
+    ) {
+        try {
+            final var results = m.remoteGroupDelete(targetSentTimestamp, GroupId.unknownVersion(groupId));
+            checkSendMessageResults(results.first(), results.second());
+            return results.first();
+        } catch (IOException e) {
+            throw new Error.Failure(e.getMessage());
+        } catch (GroupNotFoundException | NotAGroupMemberException e) {
+            throw new Error.GroupNotFound(e.getMessage());
+        }
+    }
+
+    @Override
     public long sendMessageReaction(
             final String emoji, final boolean remove, final String targetAuthor, final long targetSentTimestamp, final String recipient
     ) {


### PR DESCRIPTION
Dbus implementation of RemoteDelete data message.
Fixes #592 
A new command (remoteDelete) and new dbus & cli methods (remoteDelete, remoteGroupDelete) introduced.
Documentation (both cli and dbus) updated accordingly.
Build passed, tested.