### PR TITLE
signal-cli.service adjustment for automatic startup after reboot

### DIFF
--- a/data/signal-cli.service
+++ b/data/signal-cli.service
@@ -13,4 +13,5 @@ User=signal-cli
 BusName=org.asamk.Signal
 
 [Install]
+WantedBy=multi-user.target
 Alias=dbus-org.asamk.Signal.service


### PR DESCRIPTION
The configuration file [data/signal-cli.service](data/signal-cli.service) for systemd unit works, but the service doesn't automatically start up after reboot (at least not on Centos 7 and of course with `systemctl enable signal-cli.service` satisfied).
Therefore I suggest the adjustment in this pull request, which instructs Centos 7 to start the service during standard startup scenario.
There might be further fine-tuning advisable, but I haven't had more time to go through it and this works.
Fixes #594

For anybody struggling to get this working — this is how you edit the service if you have already set it up:
edit the systemd unit conf file `signal-cli.service` on your system...
... and then reload the service configuration and recreate the symlinks that might have been created:
```
# systemctl daemon-reload
# systemctl disable signal-cli
# systemctl enable signal-cli
```