### PR TITLE
Enables reproducible builds.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,12 @@ configurations {
     }
 }
 
+
+tasks.withType<AbstractArchiveTask>().configureEach {
+  isPreserveFileTimestamps = false
+  isReproducibleFileOrder = true
+}
+
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
 }


### PR DESCRIPTION
Gradle 7 supports reproducible builds! To use this functionality, only a very small patch is required.


```
  isPreserveFileTimestamps = false
  isReproducibleFileOrder = true
  ```
  
  Without these settings:
  
  ``` shell
echo ( ./gradlew clean && ./gradlew build ) > /dev/null && md5sum ./build/libs/*.jar && echo ( ./gradlew clean && ./gradlew build ) > /dev/null && md5sum ./build/libs/*.jar
a4d4deed6928244411d59b3eefb5cf23  ./build/libs/signal-cli-0.8.1.jar
5bf62106bae50c081579988acbeec9e1  ./build/libs/signal-cli-0.8.1.jar
```

With these settings:

``` shell
echo ( ./gradlew clean && ./gradlew build ) > /dev/null && md5sum ./build/libs/*.jar && echo ( ./gradlew clean && ./gradlew build ) > /dev/null && md5sum ./build/libs/*.jar
3c799793e9b0faf06a17eb1817780fb2  ./build/libs/signal-cli-0.8.1.jar
3c799793e9b0faf06a17eb1817780fb2  ./build/libs/signal-cli-0.8.1.jar
```

Thanks for your consideration and help!