### PR TITLE
Enable unlimited strength crypto via system Security property

### DIFF
--- a/src/main/java/org/asamk/signal/Main.java
+++ b/src/main/java/org/asamk/signal/Main.java
@@ -35,6 +35,8 @@ import java.security.Security;
 public class Main {
 
     public static void main(String[] args) {
+        // enable unlimited strength crypto via Policy, supported on relevant JREs
+        Security.setProperty("crypto.policy", "unlimited");
         installSecurityProviderWorkaround();
 
         // Configuring the logger needs to happen before any logger is initialized


### PR DESCRIPTION
JRE11+ supports enabling unlimited strength crypto at runtime via system property.

This factors out a possible exception pathway, ie

> WARN org.asamk.signal.util.ErrorUtils - If you use an Oracle JRE please check if you have unlimited strength crypto enabled, see README
