### PR TITLE
extend DBus signals with a field for mentions

### DIFF
--- a/man/signal-cli-dbus.5.adoc
+++ b/man/signal-cli-dbus.5.adoc
@@ -223,7 +223,7 @@ isRegistred -> result<b>::
 
 == Signals
 
-SyncMessageReceived (timestamp<x>, sender<s>, destination<s>, groupId<ay>,message<s>, attachments<as>)::
+SyncMessageReceived (timestamp<x>, sender<s>, destination<s>, groupId<ay>, message<s>, mentions<a(sii)>, attachments<as>)::
 The sync message is received when the user sends a message from a linked device.
 
 ReceiptReceived (timestamp<x>, sender<s>)::
@@ -232,11 +232,12 @@ ReceiptReceived (timestamp<x>, sender<s>)::
 
 This signal is sent by each recipient (e.g. each group member) after the message was successfully delivered to the device
 
-MessageReceived(timestamp<x>, sender<s>, groupId<ay>, message<s>, attachments<as>)::
+MessageReceived(timestamp<x>, sender<s>, groupId<ay>, message<s>, mentions<a(sii)>, attachments<as>)::
 * timestamp   : Integer value that is used by the system to send a ReceiptReceived reply
 * sender      : Phone number of the sender
 * groupId     : Byte array representing the internal group identifier (empty when private message)
 * message     : Message text
+* mentions    : Struct array of mentions. A mention consists of a user name, its position in the message string and its length.
 * attachments : String array of filenames for the attachments. These files are located in the signal-cli storage and the current user needs to have read access there
 
 This signal is received whenever we get a private message or a message is posted in a group we are an active member

--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -1,5 +1,6 @@
 package org.asamk;
 
+import org.asamk.signal.dbus.DbusMention;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.DBusInterface;
@@ -101,6 +102,7 @@ public interface Signal extends DBusInterface {
         private final String sender;
         private final byte[] groupId;
         private final String message;
+        private final List<DbusMention> mentions;
         private final List<String> attachments;
 
         public MessageReceived(
@@ -109,13 +111,15 @@ public interface Signal extends DBusInterface {
                 String sender,
                 byte[] groupId,
                 String message,
+                List<DbusMention> mentions,
                 List<String> attachments
         ) throws DBusException {
-            super(objectpath, timestamp, sender, groupId, message, attachments);
+            super(objectpath, timestamp, sender, groupId, message, mentions, attachments);
             this.timestamp = timestamp;
             this.sender = sender;
             this.groupId = groupId;
             this.message = message;
+            this.mentions = mentions;
             this.attachments = attachments;
         }
 
@@ -133,6 +137,10 @@ public interface Signal extends DBusInterface {
 
         public String getMessage() {
             return message;
+        }
+
+        public List<DbusMention> getMentions() {
+            return mentions;
         }
 
         public List<String> getAttachments() {
@@ -167,6 +175,7 @@ public interface Signal extends DBusInterface {
         private final String destination;
         private final byte[] groupId;
         private final String message;
+        private final List<DbusMention> mentions;
         private final List<String> attachments;
 
         public SyncMessageReceived(
@@ -176,14 +185,16 @@ public interface Signal extends DBusInterface {
                 String destination,
                 byte[] groupId,
                 String message,
+                List<DbusMention> mentions,
                 List<String> attachments
         ) throws DBusException {
-            super(objectpath, timestamp, source, destination, groupId, message, attachments);
+            super(objectpath, timestamp, source, destination, groupId, message, mentions, attachments);
             this.timestamp = timestamp;
             this.source = source;
             this.destination = destination;
             this.groupId = groupId;
             this.message = message;
+            this.mentions = mentions;
             this.attachments = attachments;
         }
 
@@ -205,6 +216,10 @@ public interface Signal extends DBusInterface {
 
         public String getMessage() {
             return message;
+        }
+
+        public List<DbusMention> getMentions() {
+            return mentions;
         }
 
         public List<String> getAttachments() {

--- a/src/main/java/org/asamk/signal/JsonDbusReceiveMessageHandler.java
+++ b/src/main/java/org/asamk/signal/JsonDbusReceiveMessageHandler.java
@@ -1,6 +1,7 @@
 package org.asamk.signal;
 
 import org.asamk.Signal;
+import org.asamk.signal.dbus.DbusMention;
 import org.asamk.signal.manager.Manager;
 import org.asamk.signal.manager.groups.GroupUtils;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
@@ -74,6 +75,7 @@ public class JsonDbusReceiveMessageHandler extends JsonReceiveMessageHandler {
                                 getLegacyIdentifier(sender),
                                 groupId != null ? groupId : new byte[0],
                                 message.getBody().isPresent() ? message.getBody().get() : "",
+                                JsonDbusReceiveMessageHandler.getMentions(message, m),
                                 JsonDbusReceiveMessageHandler.getAttachments(message, m)));
                     } catch (DBusException e) {
                         e.printStackTrace();
@@ -99,6 +101,7 @@ public class JsonDbusReceiveMessageHandler extends JsonReceiveMessageHandler {
                                             : "",
                                     groupId != null ? groupId : new byte[0],
                                     message.getBody().isPresent() ? message.getBody().get() : "",
+                                    JsonDbusReceiveMessageHandler.getMentions(message, m),
                                     JsonDbusReceiveMessageHandler.getAttachments(message, m)));
                         } catch (DBusException e) {
                             e.printStackTrace();
@@ -124,6 +127,16 @@ public class JsonDbusReceiveMessageHandler extends JsonReceiveMessageHandler {
             }
         }
         return attachments;
+    }
+
+    static private List<DbusMention> getMentions(SignalServiceDataMessage message, Manager m) {
+        var mentions = new ArrayList<DbusMention>();
+        if (message.getMentions().isPresent()) {
+            for (var mention : message.getMentions().get()) {
+                mentions.add(new DbusMention(mention, m));
+            }
+        }
+        return mentions;
     }
 
     @Override

--- a/src/main/java/org/asamk/signal/dbus/DbusMention.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusMention.java
@@ -1,0 +1,28 @@
+package org.asamk.signal.dbus;
+
+import org.asamk.signal.manager.Manager;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.whispersystems.signalservice.api.messages.SignalServiceDataMessage;
+import org.whispersystems.signalservice.api.push.SignalServiceAddress;
+
+import static org.asamk.signal.util.Util.getLegacyIdentifier;
+
+public final class DbusMention extends Struct {
+
+    @Position(0)
+    public final String name;
+
+    @Position(1)
+    public final int start;
+
+    @Position(2)
+    public final int length;
+
+    public DbusMention(SignalServiceDataMessage.Mention mention, Manager m) {
+        this.name = getLegacyIdentifier(m.resolveSignalServiceAddress(new SignalServiceAddress(mention.getUuid(),
+                null)));
+        this.start = mention.getStart();
+        this.length = mention.getLength();
+    }
+}


### PR DESCRIPTION
This change affects the DBus signals `SyncMessageReceived` and `MessageReceived`.
Mentions are represented as an array of structs.
Each mention holds the name of the mentioned user, its position and
length.