### PR TITLE
WIP: reflect config to serialize jsonrpc

### DIFF
--- a/graalvm-config-dir/reflect-config.json
+++ b/graalvm-config-dir/reflect-config.json
@@ -487,6 +487,26 @@
   "allDeclaredConstructors":true
 },
 {
+  "name": "org.asamk.signal.jsonrpc.JsonRpcBulkMessage",
+  "allDeclaredFields": true
+},
+{
+  "name": "org.asamk.signal.jsonrpc.JsonRpcException",
+  "allDeclaredFields": true
+},
+{
+  "name": "org.asamk.signal.jsonrpc.JsonRpcMessage",
+  "allDeclaredFields": true
+},
+{
+  "name": "org.asamk.signal.jsonrpc.JsonRpcRequest",
+  "allDeclaredFields": true
+},
+{
+  "name":"org.asamk.signal.jsonrpc.JsonRpcResponse",
+  "allDeclaredFields":true
+},
+{
   "name":"org.asamk.signal.manager.storage.contacts.LegacyJsonContactsStore",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,


### PR DESCRIPTION
Currently, trying to use jsonRpc on native-image produces:

```
java.lang.AssertionError: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.asamk.signal.jsonrpc.JsonRpcResponse and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)
```

The tracing agent doesn't notice anything about this, and my changes here don't fix the problem.