### PR TITLE
base 64 helper functions for Dbus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.gitignore
 .gradle/
 .idea/*
 !.idea/codeStyles/
@@ -11,3 +12,6 @@ local.properties
 .settings/
 out/
 .DS_Store
+.asciidoctorconfig.adoc
+patches/
+signal-cli

--- a/man/signal-cli-dbus.5.adoc
+++ b/man/signal-cli-dbus.5.adoc
@@ -7,7 +7,7 @@ vim:set ts=4 sw=4 tw=82 noet:
 
 == Name
 
-DBus API for signal-cli - A commandline and dbus interface for the Signal messenger
+signal-cli-dbus - DBus API for signal-cli(1)
 
 == Synopsis
 
@@ -29,53 +29,125 @@ method(arg1<type>, arg2<type>, ...) -> return<type>
 
 Where <type> is according to DBus specification:
 
+* <a>   : Array of ...
 * <s>   : String
-* <ay>  : Byte Array
-* <aay> : Array of Byte Arrays
-* <as>  : String Array
-* <ax>  : Array of signed 64 bit integer
-* <b>   : Boolean (0|1)
-* <x>   : Signed 64 bit integer
+* <y>   : Byte
+* <b>   : Boolean (false|true)
+* <x>   : Signed 64-bit integer (long)
+* <i>   : Signed 32-bit integer (int)
 * <>    : no return value
 
 Exceptions are the names of the Java Exceptions returned in the body field. They typically contain an additional message with details. All Exceptions begin with "org.asamk.Signal.Error." which is omitted here for better readability.
 
 Phone numbers always have the format +<countrycode><regional number>
 
-== Methods
+=== Control methods
+These methods are available if the daemon is started anonymously (without an explicit `-u USERNAME`). 
+Requests are sent to `/org/asamk/Signal`; requests related to individual accounts are sent to 
+`/org/asamk/Signal/_441234567890` where the + dialing code is replaced by an underscore (_). 
+Only `version()` is activated in single-user mode; the rest are disabled.
 
-updateGroup(groupId<ay>, newName<s>, members<as>, avatar<s>) -> groupId<ay>::
-* groupId  : Byte array representing the internal group identifier
-* newName  : New name of group (empty if unchanged)
-* members  : String array of new members to be invited to group
-* avatar   : Filename of avatar picture to be set for group (empty if none)
+link() -> deviceLinkUri<s>::
+link(newDeviceName<s>) -> deviceLinkUri<s>::
+* newDeviceName : Name to give new device (defaults to "cli" if no name is given)
+* deviceLinkUri : URI of newly linked device
 
-Exceptions: AttachmentInvalid, Failure, InvalidNumber, GroupNotFound
+Returns a URI of the form "tsdevice:/?uuid=...". This can be piped to a QR encoder to create a display that
+can be captured by a Signal smartphone client. For example:
 
-updateProfile(newName<s>, about <s>, aboutEmoji <s>, avatar<s>, remove<b>) -> <>::
-* newName     : New name for your own profile (empty if unchanged)
-* about       : About message for profile (empty if unchanged)
-* aboutEmoji  : Emoji for profile (empty if unchanged)
-* avatar      : Filename of avatar picture for profile (empty if unchanged)
-* remove      : Set to 1 if the existing avatar picture should be removed
+`dbus-send --session --dest=org.asamk.Signal --type=method_call --print-reply /org/asamk/Signal org.asamk.Signal.link string:"My secondary client"|tr '\n' '\0'|sed 's/.*string //g'|sed 's/\"//g'|qrencode -s10 -tANSI256`
 
-Exceptions: Failure
+Exception: Failure
 
-setContactBlocked(number<s>, block<b>) -> <>::
-* number  : Phone number affected by method
-* block   : 0=remove block , 1=blocked
+listAccounts() -> accountList<as>::
+* accountList : Array of all attached accounts in DBus object path form
 
-Messages from blocked numbers will no longer be forwarded via DBus.
+Exceptions: None
 
-Exceptions: InvalidNumber
+register(number<s>, voiceVerification<b>) -> <>::
+* number            : Phone number
+* voiceVerification : true = use voice verification; false = use SMS verification
 
-setGroupBlocked(groupId<ay>, block<b>) -> <>::
-* groupId : Byte array representing the internal group identifier
-* block   : 0=remove block , 1=blocked
+Exceptions: Failure, InvalidNumber, RequiresCaptcha
 
-Messages from blocked groups will no longer be forwarded via DBus.
+registerWithCaptcha(number<s>, voiceVerification<b>, captcha<s>) -> <>::
+* number            : Phone number
+* voiceVerification : true = use voice verification; false = use SMS verification
+* captcha           : Captcha string
 
-Exceptions: GroupNotFound
+Exceptions: Failure, InvalidNumber, RequiresCaptcha
+
+verify(number<s>, verificationCode<s>) -> <>::
+* number            : Phone number
+* verificationCode  : Code received from Signal after successful registration request
+
+Command fails if PIN was set after previous registration; use verifyWithPin instead.
+
+Exception: Failure, InvalidNumber
+
+verifyWithPin(number<s>, verificationCode<s>, pin<s>) -> <>::
+* number            : Phone number
+* verificationCode  : Code received from Signal after successful registration request
+* pin               : PIN you set with setPin command after verifying previous registration
+
+Exception: Failure, InvalidNumber
+
+version() -> version<s>::
+* version : Version string of signal-cli
+
+Exceptions: None
+
+=== Methods for groups
+
+getGroupIds() -> groupList<aay>::
+groupList : Array of Byte arrays representing the internal group identifiers
+
+All groups known are returned, regardless of their active or blocked status. To query that use isMember() and isGroupBlocked()
+
+Exceptions: None
+
+getGroupIds(dummy<s>) -> groupList<as>::
+* dummy     : any string (ignored by method; forces output to be identical with getGroupIdsBase64)
+* groupList : Array of strings representing the internal group identifiers
+
+Exceptions: None
+
+getGroupIdsBase64() -> groupList<as>::
+* groupList : Array of strings representing the internal group identifiers
+
+Exceptions: None
+
+getGroupMembers(groupId<ay>) -> members<as>::
+getGroupMembers(base64GroupId<s>) -> members<as>::
+* members       : String array with the phone numbers of all active members of a group
+* groupId       : Byte array representing the internal group identifier
+* base64GroupId : String with base64 encoded group identifier
+
+Exceptions: InvalidGroupId, Failure
+
+getGroupName(groupId<ay>) -> groupName<s>::
+getGroupName(base64GroupId<s>) -> groupName<s>::
+* groupName     : The display name of the group
+* groupId       : Byte array representing the internal group identifier
+* base64GroupId : String with base64 encoded group identifier
+
+Exceptions: InvalidGroupId, Failure
+
+isGroupBlocked(groupId<ay>) -> state<b>::
+isGroupBlocked(base64GroupId<s>) -> state<b>::
+* groupId       : Byte array representing the internal group identifier
+* base64GroupId : String with base64 encoded group identifier
+* state         : false=not blocked, true=blocked
+
+Exceptions: None; for unknown groups false is returned
+
+isMember(groupId<ay>) -> active<b>::
+isMember(base64GroupId<s>) -> active<b>::
+* groupId       : Byte array representing the internal group identifier
+* base64GroupId : String with base64 encoded group identifier
+* active        : true=active member; false=not active member
+
+InvalidGroupId, Failure
 
 joinGroup(inviteURI<s>) -> <>::
 * inviteURI : String starting with https://signal.group which is generated when you share a group link via Signal App
@@ -83,71 +155,109 @@ joinGroup(inviteURI<s>) -> <>::
 Exceptions: Failure
 
 quitGroup(groupId<ay>) -> <>::
-* groupId : Byte array representing the internal group identifier
+quitGroup(base64GroupId<s>) -> <>::
+* groupId       : Byte array representing the internal group identifier
+* base64GroupId : String with base64 encoded group identifier
 
 Note that quitting a group will not remove the group from the getGroupIds command, but set it inactive which can be tested with isMember()
 
 Exceptions: GroupNotFound, Failure
 
-isMember(groupId<ay>) -> active<b>::
-* groupId : Byte array representing the internal group identifier
-
-Note that this method does not raise an Exception for a non-existing/unknown group but will simply return 0 (false)
-
-sendEndSessionMessage(recipients<as>) -> <>::
-* recipients : Array of phone numbers 
-
-Exceptions: Failure, InvalidNumber, UntrustedIdentity
-
 sendGroupMessage(message<s>, attachments<as>, groupId<ay>) -> timestamp<x>::
-* message     : Text to send (can be UTF8)
-* attachments : String array of filenames to send as attachments (passed as filename, so need to be readable by the user signal-cli is running under)
-* groupId     : Byte array representing the internal group identifier
-* timestamp   : Can be used to identify the corresponding signal reply
+sendGroupMessage(message<s>, attachments<as>, base64GroupId<s>) -> timestamp<x>::
+* message       : Text to send (can be UTF8)
+* attachments   : String array of filenames to send as attachments (passed as filename, so need to be readable by the user signal-cli is running under)
+* groupId       : Byte array representing the internal group identifier
+* base64GroupId : String with base64 encoded group identifier
+* timestamp     : Can be used to identify the corresponding signal reply
 
 Exceptions: GroupNotFound, Failure, AttachmentInvalid
 
-sendNoteToSelfMessage(message<s>, attachments<as>) -> timestamp<x>::
-* message     : Text to send (can be UTF8)
-* attachments : String array of filenames to send as attachments (passed as filename, so need to be readable by the user signal-cli is running under)
-* timestamp   : Can be used to identify the corresponding signal reply
+sendGroupMessageReaction(emoji<s>, remove<b>, targetAuthor<s>, targetSentTimestamp<x>, groupId<ay>) -> timestamp<x>::
+sendGroupMessageReaction(emoji<s>, remove<b>, targetAuthor<s>, targetSentTimestamp<x>, base64GroupId<s>) -> timestamp<x>::
+* emoji               : Unicode grapheme cluster of the emoji
+* remove              : Boolean, whether a previously sent reaction (emoji) should be removed
+* targetAuthor        : String with the phone number of the author of the message to which to react
+* targetSentTimestamp : Long representing timestamp of the message to which to react
+* groupId             : Byte array with base64 encoded group identifier
+* base64GroupId       : String with base64 encoded group identifier
+* timestamp           : Long, can be used to identify the corresponding signal reply
 
-Exceptions: Failure, AttachmentInvalid
+Exceptions: Failure, InvalidNumber, GroupNotFound
+
+sendGroupRemoteDeleteMessage(targetSentTimestamp<x>, groupId<ay>) -> timestamp<x>::
+sendGroupRemoteDeleteMessage(targetSentTimestamp<x>, base64GroupId<s>) -> timestamp<x>::
+* targetSentTimestamp : Long representing timestamp of the message to delete
+* groupId             : Byte array with base64 encoded group identifier
+* base64GroupId       : String with base64 encoded group identifier
+* timestamp           : Long, can be used to identify the corresponding signal reply
+
+Exceptions: Failure, GroupNotFound, InvalidGroupId
+
+setGroupBlocked(groupId<ay>, block<b>) -> <>::
+setGroupBlocked(base64GroupId<s>, block<b>) -> <>::
+* groupId       : Byte array representing the internal group identifier
+* base64GroupId : String with base64 encoded group identifier
+* block         : false=remove block, true=blocked
+
+Messages from blocked groups will no longer be forwarded via DBus.
+
+Exceptions: GroupNotFound
+
+updateGroup(groupId<ay>, newName<s>, members<as>, avatar<s>) -> groupId<ay>::
+updateGroup(base64GroupId<s>, newName<s>, members<as>, avatar<s>) -> base64GroupId<s>::
+* groupId       : Byte array representing the internal group identifier
+* base64GroupId : String with base64 encoded group identifier
+* newName       : New name of group (empty if unchanged)
+* members       : String array of new members to be invited to group
+* avatar        : Filename of avatar picture to be set for group (empty if none)
+
+If groupId (or base64GroupId) is empty, creates a group with a random identifier
+and returns it. Otherwise, updates group as indicated.
+
+Exceptions: AttachmentInvalid, Failure, InvalidNumber, GroupNotFound
+
+=== Methods for individual(s)
+
+getContactName(number<s>) -> name<s>::
+* number  : Phone number
+* name    : Contact's name in local storage (from the master device for a linked account, or the one set with setContactName); if not set, contact's profile name is used
+
+Exception: InvalidNumber
+
+getContactNumber(name<s>) -> numbers<as>::
+* numbers : String array of phone numbers
+* name    : Contact or profile name ("firstname lastname")
+
+Searches contacts and known profiles for a given name and returns the list of all known numbers. May result in e.g. two entries if a contact and profile name is set.
+
+Exception: Failure
+
+isContactBlocked(number<s>) -> state<b>::
+* number  : Phone number
+* state   : true=blocked, false=not blocked
+
+Exception: InvalidNumber for an incorrectly formatted phone number. For unknown numbers, false is returned, but no exception is raised.
+
+isRegistered -> result<b>::
+* result : Currently always returns true
+
+sendEndSessionMessage(recipients<as>) -> <>::
+* recipients : Array of phone numbers
+
+Exceptions: Failure, InvalidNumber, UntrustedIdentity
 
 sendMessage(message<s>, attachments<as>, recipient<s>) -> timestamp<x>::
 sendMessage(message<s>, attachments<as>, recipients<as>) -> timestamp<x>::
 * message     : Text to send (can be UTF8)
 * attachments : String array of filenames to send as attachments (passed as filename, so need to be readable by the user signal-cli is running under)
 * recipient   : Phone number of a single recipient
-* recipients  : Array of phone numbers 
+* recipients  : Array of phone numbers
 * timestamp   : Can be used to identify the corresponding signal reply
 
 Depending on the type of the recipient field this sends a message to one or multiple recipients.
 
 Exceptions: AttachmentInvalid, Failure, InvalidNumber, UntrustedIdentity
-
-sendTyping(recipient<s>, stop<b>) -> <>::
-* recipient             : Phone number of a single recipient
-* targetSentTimestamp   : True, if typing state should be stopped
-
-Exceptions: Failure, GroupNotFound, UntrustedIdentity
-
-
-sendReadReceipt(recipient<s>, targetSentTimestamp<ax>) -> <>::
-* recipient             : Phone number of a single recipient
-* targetSentTimestamp   : Array of Longs to identify the corresponding signal messages
-
-Exceptions: Failure, UntrustedIdentity
-
-sendGroupMessageReaction(emoji<s>, remove<b>, targetAuthor<s>, targetSentTimestamp<x>, groupId<ay>) -> timestamp<x>::
-* emoji               : Unicode grapheme cluster of the emoji
-* remove              : Boolean, whether a previously sent reaction (emoji) should be removed
-* targetAuthor        : String with the phone number of the author of the message to which to react
-* targetSentTimestamp : Long representing timestamp of the message to which to react
-* groupId             : Byte array with base64 encoded group identifier
-* timestamp           : Long, can be used to identify the corresponding signal reply
-
-Exceptions: Failure, InvalidNumber, GroupNotFound
 
 sendMessageReaction(emoji<s>, remove<b>, targetAuthor<s>, targetSentTimestamp<x>, recipient<s>) -> timestamp<x>::
 sendMessageReaction(emoji<s>, remove<b>, targetAuthor<s>, targetSentTimestamp<x>, recipients<as>) -> timestamp<x>::
@@ -163,12 +273,11 @@ Depending on the type of the recipient(s) field this sends a reaction to one or 
 
 Exceptions: Failure, InvalidNumber
 
-sendGroupRemoteDeleteMessage(targetSentTimestamp<x>, groupId<ay>) -> timestamp<x>::
-* targetSentTimestamp : Long representing timestamp of the message to delete
-* groupId             : Byte array with base64 encoded group identifier
-* timestamp           : Long, can be used to identify the corresponding signal reply
+sendReadReceipt(recipient<s>, targetSentTimestamp<ax>) -> <>::
+* recipient             : Phone number of a single recipient
+* targetSentTimestamp   : Array of Longs to identify the corresponding signal messages
 
-Exceptions: Failure, GroupNotFound
+Exceptions: Failure, UntrustedIdentity
 
 sendRemoteDeleteMessage(targetSentTimestamp<x>, recipient<s>) -> timestamp<x>::
 sendRemoteDeleteMessage(targetSentTimestamp<x>, recipients<as>) -> timestamp<x>::
@@ -181,63 +290,58 @@ Depending on the type of the recipient(s) field this deletes a message with one 
 
 Exceptions: Failure, InvalidNumber
 
-getContactName(number<s>) -> name<s>::
-* number  : Phone number
-* name    : Contact's name in local storage (from the master device for a linked account, or the one set with setContactName); if not set, contact's profile name is used
+sendTyping(recipient<s>, stop<b>) -> <>::
+* recipient             : Phone number of a single recipient
+* targetSentTimestamp   : True, if typing state should be stopped
+
+Exceptions: Failure, GroupNotFound, UntrustedIdentity
+
+setContactBlocked(number<s>, block<b>) -> <>::
+* number  : Phone number affected by method
+* block   : false=remove block , true=blocked
+
+Messages from blocked numbers will no longer be forwarded via DBus.
+
+Exceptions: InvalidNumber
 
 setContactName(number<s>,name<>) -> <>::
 * number  : Phone number
 * name    : Name to be set in contacts (in local storage with signal-cli)
 
-getGroupIds() -> groupList<aay>::
-groupList : Array of Byte arrays representing the internal group identifiers
+Exceptions: InvalidNumber
 
-All groups known are returned, regardless of their active or blocked status. To query that use isMember() and isGroupBlocked()
-
-getGroupName(groupId<ay>) -> groupName<s>::
-groupName : The display name of the group 
-groupId   : Byte array representing the internal group identifier
-
-Exceptions: None, if the group name is not found an empty string is returned
-
-getGroupMembers(groupId<ay>) -> members<as>::
-members   : String array with the phone numbers of all active members of a group
-groupId   : Byte array representing the internal group identifier
-
-Exceptions: None, if the group name is not found an empty array is returned
+=== Other methods
 
 listNumbers() -> numbers<as>::
-numbers : String array of all known numbers
+* numbers : String array of all known numbers
 
 This is a concatenated list of all defined contacts as well of profiles known (e.g. peer group members or sender of received messages)
 
-getContactNumber(name<s>) -> numbers<as>::
-* numbers : Array of phone number
-* name    : Contact or profile name ("firstname lastname")
+Exceptions: None
 
-Searches contacts and known profiles for a given name and returns the list of all known numbers. May result in e.g. two entries if a contact and profile name is set.
+sendNoteToSelfMessage(message<s>, attachments<as>) -> timestamp<x>::
+* message     : Text to send (can be UTF8)
+* attachments : String array of filenames to send as attachments (passed as filename, so need to be readable by the user signal-cli is running under)
+* timestamp   : Can be used to identify the corresponding signal reply
 
-isContactBlocked(number<s>) -> state<b>::
-* number  : Phone number
-* state   : 1=blocked, 0=not blocked
+Exceptions: Failure, AttachmentInvalid
 
-Exceptions: None, for unknown numbers 0 (false) is returned
+updateProfile(newName<s>, about <s>, aboutEmoji <s>, avatar<s>, remove<b>) -> <>::
+* newName     : New name for your own profile (empty if unchanged)
+* about       : About message for profile (empty if unchanged)
+* aboutEmoji  : Emoji for profile (empty if unchanged)
+* avatar      : Filename of avatar picture for profile (empty if unchanged)
+* remove      : Set to true if the existing avatar picture should be removed
 
-isGroupBlocked(groupId<ay>) -> state<b>::
-* groupId : Byte array representing the internal group identifier
-* state   : 1=blocked, 0=not blocked
-
-Exceptions: None, for unknown groups 0 (false) is returned
+Exceptions: Failure
 
 version() -> version<s>::
 * version : Version string of signal-cli
 
-isRegistred -> result<b>::
-* result : Currently always returns 1=true
-
 == Signals
 
 SyncMessageReceived (timestamp<x>, sender<s>, destination<s>, groupId<ay>,message<s>, attachments<as>)::
+
 The sync message is received when the user sends a message from a linked device.
 
 ReceiptReceived (timestamp<x>, sender<s>)::
@@ -261,7 +365,7 @@ Send a text message (without attachment) to a contact::
 dbus-send --print-reply --type=method_call --dest="org.asamk.Signal" /org/asamk/Signal org.asamk.Signal.sendMessage string:"Message text goes here" array:string: string:+123456789
 
 Send a group message::
-dbus-send --session --print-reply --type=method_call --dest=org.asamk.Signal /org/asamk/Signal org.asamk.Signal.sendGroupMessage  string:'The message goes here'  array:string:'/path/to/attachmnt1','/path/to/attachmnt2'  array:byte:139,22,72,247,116,32,170,104,205,164,207,21,248,77,185
+dbus-send --session --print-reply --type=method_call --dest=org.asamk.Signal /org/asamk/Signal org.asamk.Signal.sendGroupMessage  string:'The message goes here'  array:string:'/path/to/attachment1','/path/to/attachment2'  array:byte:139,22,72,247,116,32,170,104,205,164,207,21,248,77,185
 
 Print the group name corresponding to a groupId; the daemon runs on system bus, and was started without an explicit `-u USERNAME`::
 dbus-send --system --print-reply --type=method_call --dest='org.asamk.Signal' /org/asamk/Signal/_1234567890 org.asamk.Signal.getGroupName array:byte:139,22,72,247,116,32,170,104,205,164,207,21,248,77,185

--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -41,6 +41,10 @@ public interface Signal extends DBusInterface {
             long targetSentTimestamp, byte[] groupId
     ) throws Error.Failure, Error.GroupNotFound, Error.InvalidGroupId;
 
+    long sendGroupRemoteDeleteMessage(
+            long targetSentTimestamp, String base64GroupId
+    ) throws Error.Failure, Error.GroupNotFound, Error.InvalidGroupId;
+
     long sendMessageReaction(
             String emoji, boolean remove, String targetAuthor, long targetSentTimestamp, String recipient
     ) throws Error.InvalidNumber, Error.Failure;
@@ -59,8 +63,16 @@ public interface Signal extends DBusInterface {
             String message, List<String> attachments, byte[] groupId
     ) throws Error.GroupNotFound, Error.Failure, Error.AttachmentInvalid, Error.InvalidGroupId;
 
+    long sendGroupMessage(
+            String message, List<String> attachments, String base64GroupId
+    ) throws Error.GroupNotFound, Error.Failure, Error.AttachmentInvalid, Error.InvalidGroupId;
+
     long sendGroupMessageReaction(
             String emoji, boolean remove, String targetAuthor, long targetSentTimestamp, byte[] groupId
+    ) throws Error.GroupNotFound, Error.Failure, Error.InvalidNumber, Error.InvalidGroupId;
+
+    long sendGroupMessageReaction(
+            String emoji, boolean remove, String targetAuthor, long targetSentTimestamp, String base64GroupId
     ) throws Error.GroupNotFound, Error.Failure, Error.InvalidNumber, Error.InvalidGroupId;
 
     String getContactName(String number) throws Error.InvalidNumber;
@@ -71,14 +83,28 @@ public interface Signal extends DBusInterface {
 
     void setGroupBlocked(byte[] groupId, boolean blocked) throws Error.GroupNotFound, Error.InvalidGroupId;
 
+    void setGroupBlocked(String base64GroupId, boolean blocked) throws Error.GroupNotFound, Error.InvalidGroupId;
+
     List<byte[]> getGroupIds();
 
+    List<String> getGroupIds(String dummy);
+
+    List<String> getGroupIdsBase64();
+    
     String getGroupName(byte[] groupId) throws Error.InvalidGroupId;
+
+    String getGroupName(String base64GroupId) throws Error.InvalidGroupId, Error.Failure;
 
     List<String> getGroupMembers(byte[] groupId) throws Error.InvalidGroupId;
 
+    List<String> getGroupMembers(String base64GroupId) throws Error.InvalidGroupId, Error.Failure;
+
     byte[] updateGroup(
             byte[] groupId, String name, List<String> members, String avatar
+    ) throws Error.AttachmentInvalid, Error.Failure, Error.InvalidNumber, Error.GroupNotFound, Error.InvalidGroupId;
+
+    String updateGroup(
+            String base64GroupId, String name, List<String> members, String avatar
     ) throws Error.AttachmentInvalid, Error.Failure, Error.InvalidNumber, Error.GroupNotFound, Error.InvalidGroupId;
 
     boolean isRegistered();
@@ -95,11 +121,17 @@ public interface Signal extends DBusInterface {
 
     void quitGroup(final byte[] groupId) throws Error.GroupNotFound, Error.Failure, Error.InvalidGroupId;
 
+    void quitGroup(final String base64GroupId) throws Error.GroupNotFound, Error.Failure, Error.InvalidGroupId;
+
     boolean isContactBlocked(final String number) throws Error.InvalidNumber;
 
     boolean isGroupBlocked(final byte[] groupId) throws Error.InvalidGroupId;
 
+    boolean isGroupBlocked(final String base64GroupId) throws Error.InvalidGroupId, Error.Failure;
+
     boolean isMember(final byte[] groupId) throws Error.InvalidGroupId;
+
+    boolean isMember(final String base64GroupId) throws Error.InvalidGroupId, Error.Failure;
 
     byte[] joinGroup(final String groupLink) throws Error.Failure;
 


### PR DESCRIPTION
implement alternate versions of commands that take a Group Id in
the form of byte[] to permit passing a string in base 64 format.

Methods affected:
- getGroupIds
- getGroupMembers
- getGroupName
- isGroupBlocked
- isMember
- quitGroup
- sendGroupMessage
- sendGroupMessageReaction
- sendGroupRemoteDeleteMessage
- setGroupBlocked
- updateGroup

Implement new helper function specifically for base 64 identifiers:
- getGroupIdsBase64()

Update and reorganize Dbus API documentation.