### PR TITLE
implement Dbus unregister/unlisten methods

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/ProvisioningManager.java
+++ b/lib/src/main/java/org/asamk/signal/manager/ProvisioningManager.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.whispersystems.libsignal.IdentityKeyPair;
 import org.whispersystems.libsignal.util.KeyHelper;
 import org.whispersystems.signalservice.api.SignalServiceAccountManager;
+import org.whispersystems.signalservice.api.SignalServiceAccountManager.NewDeviceRegistrationReturn;
 import org.whispersystems.signalservice.api.groupsv2.ClientZkOperations;
 import org.whispersystems.signalservice.api.groupsv2.GroupsV2Operations;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
@@ -90,7 +91,13 @@ public class ProvisioningManager {
     }
 
     public Manager finishDeviceLink(String deviceName) throws IOException, TimeoutException, UserAlreadyExists {
-        var ret = accountManager.getNewDeviceRegistration(tempIdentityKey);
+        NewDeviceRegistrationReturn ret;
+        logger.info("Waiting for addDevice request...");
+        try {
+            ret = accountManager.getNewDeviceRegistration(tempIdentityKey);
+        } catch (IOException | TimeoutException e) {
+            throw new TimeoutException(e.getMessage());
+        }
         var number = ret.getNumber();
 
         logger.info("Received link information from {}, linking in progress ...", number);

--- a/man/signal-cli-dbus.5.adoc
+++ b/man/signal-cli-dbus.5.adoc
@@ -114,6 +114,22 @@ sendNoteToSelfMessage(message<s>, attachments<as>) -> timestamp<x>::
 
 Exceptions: Failure, AttachmentInvalid
 
+unlisten() -> <>::
+unlisten(keepData<b>) -> <>::
+* keepData  : true or omitted = keep files in data directory; false = delete files
+
+Stops the current device from listening to DBus. In single-user mode, kills the daemon.
+
+Exception: Failure
+
+unregister() -> <>::
+unregister(keepData<b>) -> <>::
+* keepData  : true or omitted = keep files in data directory; false = delete files
+
+Unregisters the current device. In single-user mode, kills the daemon.
+
+Exception: Failure
+
 sendMessage(message<s>, attachments<as>, recipient<s>) -> timestamp<x>::
 sendMessage(message<s>, attachments<as>, recipients<as>) -> timestamp<x>::
 * message     : Text to send (can be UTF8)

--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -83,6 +83,12 @@ public interface Signal extends DBusInterface {
 
     boolean isRegistered();
 
+    void unlisten() throws Error.Failure;
+    void unlisten(boolean keepData) throws Error.Failure;
+
+    void unregister() throws Error.Failure;
+    void unregister(boolean keepData) throws Error.Failure;
+
     void updateProfile(
             String name, String about, String aboutEmoji, String avatarPath, boolean removeAvatar
     ) throws Error.Failure;

--- a/src/main/java/org/asamk/signal/commands/MultiLocalCommand.java
+++ b/src/main/java/org/asamk/signal/commands/MultiLocalCommand.java
@@ -5,13 +5,22 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import org.asamk.signal.OutputWriter;
 import org.asamk.signal.commands.exceptions.CommandException;
 import org.asamk.signal.manager.Manager;
+import org.asamk.signal.manager.storage.identities.TrustNewIdentity;
 
 import java.util.List;
 
 public interface MultiLocalCommand extends LocalCommand {
 
     void handleCommand(
-            Namespace ns, List<Manager> m, SignalCreator c, OutputWriter outputWriter
+            Namespace ns, List<Manager> managers, SignalCreator c, OutputWriter outputWriter
+    ) throws CommandException;
+
+    void handleCommand(
+            Namespace ns, Manager m, SignalCreator c, OutputWriter outputWriter, TrustNewIdentity trustNewIdentity
+    ) throws CommandException;
+
+    public void handleCommand(
+            Namespace ns, List<Manager> managers, SignalCreator c, OutputWriter outputWriter, TrustNewIdentity trustNewIdentity
     ) throws CommandException;
 
     @Override


### PR DESCRIPTION
implemented two related Dbus methods:
- unregister
- unlisten

improved error handling for Dbus method:
- link

fixed logic error in Manager.java (line 876) because daemon
could still be running after a particular account is unregistered.

broadened WebSocketUnavailableException (line 913) to catch all
IOExceptions caused by unregistering account while daemon is running.

specified error message handling in ProvisioningManager.java and
DbusSignalControlImpl.java for link subcommand.

helper methods:
- getPathConfig in Manager.java
- private removeUserData in DbusSignalImpl.java