### PR TITLE
Dbus listen/unlisten register/unregister

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/Manager.java
+++ b/lib/src/main/java/org/asamk/signal/manager/Manager.java
@@ -94,6 +94,8 @@ public interface Manager extends Closeable {
 
     void checkAccountState() throws IOException;
 
+    SignalAccount getAccount();
+
     Map<String, Pair<String, UUID>> areUsersRegistered(Set<String> numbers) throws IOException;
 
     void updateAccountAttributes(String deviceName) throws IOException;

--- a/lib/src/main/java/org/asamk/signal/manager/ManagerImpl.java
+++ b/lib/src/main/java/org/asamk/signal/manager/ManagerImpl.java
@@ -922,8 +922,12 @@ public class ManagerImpl implements Manager {
         while (!Thread.interrupted()) {
             SignalServiceEnvelope envelope;
             final CachedMessage[] cachedMessage = {null};
-            account.setLastReceiveTimestamp(System.currentTimeMillis());
+            if (account == null) {
+                logger.debug("Account closed.");
+                break;
+            }
             logger.debug("Checking for new message from server");
+            account.setLastReceiveTimestamp(System.currentTimeMillis());
             try {
                 var result = signalWebSocket.readOrEmpty(unit.toMillis(timeout), envelope1 -> {
                     final var recipientId = envelope1.hasSourceUuid()
@@ -955,7 +959,7 @@ public class ManagerImpl implements Manager {
                 } else {
                     throw e;
                 }
-            } catch (WebSocketUnavailableException e) {
+            } catch (IOException e) {
                 logger.debug("Pipe unexpectedly unavailable, connecting");
                 signalWebSocket.connect();
                 continue;

--- a/lib/src/main/java/org/asamk/signal/manager/ManagerImpl.java
+++ b/lib/src/main/java/org/asamk/signal/manager/ManagerImpl.java
@@ -248,6 +248,11 @@ public class ManagerImpl implements Manager {
     }
 
     @Override
+    public SignalAccount getAccount() {
+        return account;
+    }
+
+    @Override
     public void checkAccountState() throws IOException {
         if (account.getLastReceiveTimestamp() == 0) {
             logger.info("The Signal protocol expects that incoming messages are regularly received.");

--- a/lib/src/main/java/org/asamk/signal/manager/ProvisioningManager.java
+++ b/lib/src/main/java/org/asamk/signal/manager/ProvisioningManager.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.whispersystems.libsignal.IdentityKeyPair;
 import org.whispersystems.libsignal.util.KeyHelper;
 import org.whispersystems.signalservice.api.SignalServiceAccountManager;
+import org.whispersystems.signalservice.api.SignalServiceAccountManager.NewDeviceRegistrationReturn;
 import org.whispersystems.signalservice.api.groupsv2.ClientZkOperations;
 import org.whispersystems.signalservice.api.groupsv2.GroupsV2Operations;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
@@ -90,7 +91,13 @@ public class ProvisioningManager {
     }
 
     public Manager finishDeviceLink(String deviceName) throws IOException, TimeoutException, UserAlreadyExists {
-        var ret = accountManager.getNewDeviceRegistration(tempIdentityKey);
+        NewDeviceRegistrationReturn ret;
+        logger.info("Waiting for addDevice request...");
+        try {
+            ret = accountManager.getNewDeviceRegistration(tempIdentityKey);
+        } catch (IOException | TimeoutException e) {
+            throw new TimeoutException(e.getMessage());
+        }
         var number = ret.getNumber();
 
         logger.info("Received link information from {}, linking in progress ...", number);

--- a/lib/src/main/java/org/asamk/signal/manager/RegistrationManager.java
+++ b/lib/src/main/java/org/asamk/signal/manager/RegistrationManager.java
@@ -116,8 +116,9 @@ public class RegistrationManager implements Closeable {
         return new RegistrationManager(account, pathConfig, serviceConfiguration, userAgent);
     }
 
-    public void register(boolean voiceVerification, String captcha) throws IOException {
+    public void register(boolean voiceVerification, String captchaString) throws IOException {
         final ServiceResponse<RequestVerificationCodeResponse> response;
+        final var captcha = captchaString == null ? null : captchaString.replace("signalcaptcha://", "");
         if (voiceVerification) {
             response = accountManager.requestVoiceVerificationCode(getDefaultLocale(),
                     Optional.fromNullable(captcha),

--- a/man/signal-cli-dbus.5.adoc
+++ b/man/signal-cli-dbus.5.adoc
@@ -70,7 +70,7 @@ Exceptions: None
 listen(number<s>) -> <>::
 * number            : Phone number
 
-Starting checking the Signal servers on behalf of this number, and export a DBus object path for it. 
+Start checking the Signal servers on behalf of this number, and export a DBus object path for it.
 Fails if user is not already registered.
 
 Exceptions: Failure
@@ -89,6 +89,23 @@ registerWithCaptcha(number<s>, voiceVerification<b>, captcha<s>) -> <>::
 Captcha strings may be obtained from `https://signalcaptchas.org/registration/generate.html`
 
 Exceptions: Failure, InvalidNumber, RequiresCaptcha
+
+unlisten(number<s>) -> <>::
+* number            : Phone number
+* keepData  : true or omitted = keep files in data directory; false = delete files
+
+Stops the current device from listening to DBus. In single-user mode, kills the daemon.
+
+Exception: Failure
+
+unregister(number<s>) -> <>::
+unregister(number<s>, keepData<b>) -> <>::
+* number            : Phone number
+* keepData  : true or omitted = keep files in data directory; false = delete files
+
+Unregisters the current device. In single-user mode, kills the daemon.
+
+Exception: Failure
 
 verify(number<s>, verificationCode<s>) -> <>::
 * number            : Phone number
@@ -173,7 +190,7 @@ isMember(groupId<ay>) -> active<b>::
 Note that this method does not raise an Exception for a non-existing/unknown group but will simply return 0 (false)
 
 sendEndSessionMessage(recipients<as>) -> <>::
-* recipients : Array of phone numbers 
+* recipients : Array of phone numbers
 
 Exceptions: Failure, InvalidNumber, UntrustedIdentity
 
@@ -209,7 +226,7 @@ sendMessage(message<s>, attachments<as>, recipients<as>) -> timestamp<x>::
 * message     : Text to send (can be UTF8)
 * attachments : String array of filenames to send as attachments (passed as filename, so need to be readable by the user signal-cli is running under)
 * recipient   : Phone number of a single recipient
-* recipients  : Array of phone numbers 
+* recipients  : Array of phone numbers
 * timestamp   : Can be used to identify the corresponding signal reply
 
 Depending on the type of the recipient field this sends a message to one or multiple recipients.
@@ -285,7 +302,7 @@ groupList : Array of Byte arrays representing the internal group identifiers
 All groups known are returned, regardless of their active or blocked status. To query that use isMember() and isGroupBlocked()
 
 getGroupName(groupId<ay>) -> groupName<s>::
-groupName : The display name of the group 
+groupName : The display name of the group
 groupId   : Byte array representing the internal group identifier
 
 Exceptions: None, if the group name is not found an empty string is returned
@@ -361,7 +378,7 @@ removeDevice(deviceId<i>) -> <>::
 Exception: Failure
 
 updateDeviceName(deviceName<s>) -> <>::
-* deviceName : New name 
+* deviceName : New name
 
 Set a new name for this device (main or linked).
 

--- a/man/signal-cli-dbus.5.adoc
+++ b/man/signal-cli-dbus.5.adoc
@@ -67,6 +67,14 @@ listAccounts() -> accountList<as>::
 
 Exceptions: None
 
+listen(number<s>) -> <>::
+* number            : Phone number
+
+Starting checking the Signal servers on behalf of this number, and export a DBus object path for it. 
+Fails if user is not already registered.
+
+Exceptions: Failure
+
 register(number<s>, voiceVerification<b>) -> <>::
 * number            : Phone number
 * voiceVerification : true = use voice verification; false = use SMS verification
@@ -77,6 +85,8 @@ registerWithCaptcha(number<s>, voiceVerification<b>, captcha<s>) -> <>::
 * number            : Phone number
 * voiceVerification : true = use voice verification; false = use SMS verification
 * captcha           : Captcha string
+
+Captcha strings may be obtained from `https://signalcaptchas.org/registration/generate.html`
 
 Exceptions: Failure, InvalidNumber, RequiresCaptcha
 

--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -494,13 +494,16 @@ The path of the manifest.json or a zip file containing the sticker pack you wish
 === daemon
 
 signal-cli can run in daemon mode and provides an experimental dbus interface.
-If no `-u` username is given, all local users will be exported as separate dbus
-objects under the same bus name.
+If no `-u` username is given, zero or more local users as specified by the
+`--number` option will be exported as separate dbus objects under the same bus name.
+If `--number` is omitted, all local users will be exported.
 
 *--system*::
 Use DBus system bus instead of user bus.
 *--ignore-attachments*::
 Don’t download attachments of received messages.
+*--number* [NUMBER [NUMBER ...]]::
+List of zero or more  numbers for anonymous daemon to listen to (default=all)
 
 == Examples
 

--- a/src/main/java/org/asamk/Signal.java
+++ b/src/main/java/org/asamk/Signal.java
@@ -8,6 +8,7 @@ import org.freedesktop.dbus.interfaces.DBusInterface;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.messages.DBusSignal;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -16,7 +17,7 @@ import java.util.List;
  */
 public interface Signal extends DBusInterface {
 
-    String getSelfNumber();
+	String getSelfNumber();
 
     long sendMessage(
             String message, List<String> attachments, String recipient

--- a/src/main/java/org/asamk/SignalControl.java
+++ b/src/main/java/org/asamk/SignalControl.java
@@ -1,5 +1,6 @@
 package org.asamk;
 
+import org.asamk.Signal.Error;
 import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.DBusInterface;
@@ -24,11 +25,17 @@ public interface SignalControl extends DBusInterface {
 
     void verifyWithPin(String number, String verificationCode, String pin) throws Error.Failure, Error.InvalidNumber;
 
+    void listen(String number) throws Error.Failure;
+
+    void unlisten(String number) throws Error.Failure;
+
+    void unregister(String number) throws Error.Failure;
+    void unregister(String number, boolean keepData) throws Error.Failure;
+
+
     String link(String newDeviceName) throws Error.Failure;
 
     public String version();
-
-    void listen(String number) throws Error.Failure;
 
     List<DBusPath> listAccounts();
 

--- a/src/main/java/org/asamk/SignalControl.java
+++ b/src/main/java/org/asamk/SignalControl.java
@@ -28,6 +28,8 @@ public interface SignalControl extends DBusInterface {
 
     public String version();
 
+    void listen(String number) throws Error.Failure;
+
     List<DBusPath> listAccounts();
 
     interface Error {

--- a/src/main/java/org/asamk/signal/commands/DaemonCommand.java
+++ b/src/main/java/org/asamk/signal/commands/DaemonCommand.java
@@ -4,6 +4,7 @@ import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
+import org.asamk.signal.App;
 import org.asamk.signal.DbusConfig;
 import org.asamk.signal.DbusReceiveMessageHandler;
 import org.asamk.signal.JsonDbusReceiveMessageHandler;
@@ -13,14 +14,19 @@ import org.asamk.signal.OutputWriter;
 import org.asamk.signal.PlainTextWriter;
 import org.asamk.signal.commands.exceptions.CommandException;
 import org.asamk.signal.commands.exceptions.UnexpectedErrorException;
+import org.asamk.signal.commands.exceptions.UserErrorException;
 import org.asamk.signal.dbus.DbusSignalControlImpl;
 import org.asamk.signal.dbus.DbusSignalImpl;
 import org.asamk.signal.manager.Manager;
+import org.asamk.signal.manager.config.ServiceEnvironment;
+import org.asamk.signal.manager.storage.identities.TrustNewIdentity;
+
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -28,6 +34,9 @@ import java.util.concurrent.TimeUnit;
 public class DaemonCommand implements MultiLocalCommand {
 
     private final static Logger logger = LoggerFactory.getLogger(DaemonCommand.class);
+    public static DBusConnection.DBusBusType dBusType;
+    public static TrustNewIdentity trustNewIdentity;
+    public static OutputWriter outputWriter;
 
     @Override
     public String getName() {
@@ -43,6 +52,8 @@ public class DaemonCommand implements MultiLocalCommand {
         subparser.addArgument("--ignore-attachments")
                 .help("Don’t download attachments of received messages.")
                 .action(Arguments.storeTrue());
+        subparser.addArgument("--number", "--numbers").help("Phone numbers").nargs("*")
+                .help("List of zero or more numbers for anonymous daemon to listen to (default=all)");
     }
 
     @Override
@@ -54,6 +65,12 @@ public class DaemonCommand implements MultiLocalCommand {
     public void handleCommand(
             final Namespace ns, final Manager m, final OutputWriter outputWriter
     ) throws CommandException {
+        handleCommand(ns, m, null, outputWriter, null);
+    }
+
+    @Override
+    public void handleCommand(final Namespace ns, final Manager m, final SignalCreator c, final OutputWriter outputWriter, final TrustNewIdentity trustNewIdentity) throws CommandException {
+        //single-user mode
         boolean ignoreAttachments = Boolean.TRUE.equals(ns.getBoolean("ignore-attachments"));
 
         DBusConnection.DBusBusType busType;
@@ -62,6 +79,12 @@ public class DaemonCommand implements MultiLocalCommand {
         } else {
             busType = DBusConnection.DBusBusType.SESSION;
         }
+
+        this.dBusType = busType;
+        this.trustNewIdentity = trustNewIdentity;
+        this.outputWriter = outputWriter;
+
+        checkMacOS();
 
         try (var conn = DBusConnection.getConnection(busType)) {
             var objectPath = DbusConfig.getObjectPath();
@@ -73,7 +96,10 @@ public class DaemonCommand implements MultiLocalCommand {
                 t.join();
             } catch (InterruptedException ignored) {
             }
-        } catch (DBusException | IOException e) {
+        } catch (DBusException e) {
+            logger.error("Dbus command failed", e);
+            throw new UserErrorException("Dbus command failed, daemon already started on this bus.");
+        } catch (IOException e) {
             logger.error("Dbus command failed", e);
             throw new UnexpectedErrorException("Dbus command failed", e);
         }
@@ -81,8 +107,9 @@ public class DaemonCommand implements MultiLocalCommand {
 
     @Override
     public void handleCommand(
-            final Namespace ns, final List<Manager> managers, final SignalCreator c, final OutputWriter outputWriter
+            final Namespace ns, final List<Manager> managers, final SignalCreator c, final OutputWriter outputWriter, TrustNewIdentity trustNewIdentity
     ) throws CommandException {
+        //anonymous mode
         boolean ignoreAttachments = Boolean.TRUE.equals(ns.getBoolean("ignore-attachments"));
 
         DBusConnection.DBusBusType busType;
@@ -91,6 +118,12 @@ public class DaemonCommand implements MultiLocalCommand {
         } else {
             busType = DBusConnection.DBusBusType.SESSION;
         }
+
+        this.dBusType = busType;
+        this.trustNewIdentity = trustNewIdentity;
+        this.outputWriter = outputWriter;
+
+        checkMacOS();
 
         try (var conn = DBusConnection.getConnection(busType)) {
             final var signalControl = new DbusSignalControlImpl(c, m -> {
@@ -104,16 +137,56 @@ public class DaemonCommand implements MultiLocalCommand {
             }, DbusConfig.getObjectPath());
             conn.exportObject(signalControl);
 
+            List<String> daemonUsernames = ns.<String>getList("number");
+            File settingsPath = c.getSettingsPath();
+            ServiceEnvironment serviceEnvironment = c.getServiceEnvironment();
+
+            if (daemonUsernames == null) {
+                //--numbers option was not given, so add all local usernames
+                daemonUsernames = Manager.getAllLocalNumbers(settingsPath);
+                if (daemonUsernames.size() == 0) {
+                    logger.error("No users are registered yet.");
+                    throw new UserErrorException("No users are registered yetTry again with signal-cli daemon --numbers");
+                }
+            }
+
+            for (String u : daemonUsernames) {
+                try {
+                    managers.add(App.loadManager(u, settingsPath, serviceEnvironment, trustNewIdentity));
+                } catch (CommandException e) {
+                    logger.warn("Ignoring {}: {}", u, e.getMessage());
+                }
+            }
+
             for (var m : managers) {
                 signalControl.addManager(m);
             }
 
             conn.requestBusName(DbusConfig.getBusname());
+            logger.info("Starting daemon.");
 
             signalControl.run();
-        } catch (DBusException | IOException e) {
+        } catch (DBusException e) {
+            logger.error("Dbus command failed", e);
+            throw new UserErrorException("Dbus command failed, daemon alreadytarted on this bus.");
+        } catch (IOException e ) {
             logger.error("Dbus command failed", e);
             throw new UnexpectedErrorException("Dbus command failed", e);
+        }
+    }
+
+    private void checkMacOS() throws UserErrorException {
+        if (System.getProperty("os.name").toLowerCase().startsWith("mac ")) {
+            String dBusVar = System.getenv("DBUS_LAUNCHD_SESSION_BUS_SOCKET");
+            if (dBusVar == null || dBusVar.isBlank()) {
+                String message = "\n\n" +
+                        "*************************************" +
+                        "\n\nDBUS_LAUNCHD_SESSION_BUS_SOCKET is not set. Issue the command:\n\n" +
+                        "export DBUS_LAUNCHD_SESSION_BUS_SOCKET=$(launchctl getenv DBUS_LAUNCHD_SESSION_BUS_SOCKET)\n" +
+                        "\nand then try again.\n\n" +
+                        "*************************************";
+                throw new UserErrorException(message);
+            }
         }
     }
 

--- a/src/main/java/org/asamk/signal/commands/DaemonCommand.java
+++ b/src/main/java/org/asamk/signal/commands/DaemonCommand.java
@@ -216,7 +216,10 @@ public class DaemonCommand implements MultiLocalCommand {
                 initThread.join();
             } catch (InterruptedException ignored) {
             }
-            signal.close();
+            try {
+                signal.close();
+            } catch (IOException ignored) {
+            }
         });
 
         thread.start();

--- a/src/main/java/org/asamk/signal/commands/MultiLocalCommand.java
+++ b/src/main/java/org/asamk/signal/commands/MultiLocalCommand.java
@@ -5,19 +5,12 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import org.asamk.signal.OutputWriter;
 import org.asamk.signal.commands.exceptions.CommandException;
 import org.asamk.signal.manager.Manager;
+import org.asamk.signal.manager.storage.identities.TrustNewIdentity;
 
 import java.util.List;
 
 public interface MultiLocalCommand extends LocalCommand {
+    void handleCommand(Namespace ns, List<Manager> m, SignalCreator c, OutputWriter outputWriter, TrustNewIdentity trustNewIdentity) throws CommandException;
+    void handleCommand(Namespace ns, Manager m, SignalCreator c, OutputWriter outputWriter, TrustNewIdentity trustNewIdentity) throws CommandException;
 
-    void handleCommand(
-            Namespace ns, List<Manager> m, SignalCreator c, OutputWriter outputWriter
-    ) throws CommandException;
-
-    @Override
-    default void handleCommand(
-            final Namespace ns, final Manager m, final OutputWriter outputWriter
-    ) throws CommandException {
-        handleCommand(ns, List.of(m), null, outputWriter);
-    }
 }

--- a/src/main/java/org/asamk/signal/commands/MultiLocalCommand.java
+++ b/src/main/java/org/asamk/signal/commands/MultiLocalCommand.java
@@ -10,7 +10,7 @@ import org.asamk.signal.manager.storage.identities.TrustNewIdentity;
 import java.util.List;
 
 public interface MultiLocalCommand extends LocalCommand {
-    void handleCommand(Namespace ns, List<Manager> m, SignalCreator c, OutputWriter outputWriter, TrustNewIdentity trustNewIdentity) throws CommandException;
+    void handleCommand(Namespace ns, List<Manager> managers, SignalCreator c, OutputWriter outputWriter, TrustNewIdentity trustNewIdentity) throws CommandException;
     void handleCommand(Namespace ns, Manager m, SignalCreator c, OutputWriter outputWriter, TrustNewIdentity trustNewIdentity) throws CommandException;
 
 }

--- a/src/main/java/org/asamk/signal/commands/SignalCreator.java
+++ b/src/main/java/org/asamk/signal/commands/SignalCreator.java
@@ -2,10 +2,16 @@ package org.asamk.signal.commands;
 
 import org.asamk.signal.manager.ProvisioningManager;
 import org.asamk.signal.manager.RegistrationManager;
+import org.asamk.signal.manager.config.ServiceEnvironment;
 
+import java.io.File;
 import java.io.IOException;
 
 public interface SignalCreator {
+
+    File getSettingsPath();
+
+    ServiceEnvironment getServiceEnvironment();
 
     ProvisioningManager getNewProvisioningManager();
 

--- a/src/main/java/org/asamk/signal/dbus/DbusManagerImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusManagerImpl.java
@@ -23,6 +23,7 @@ import org.asamk.signal.manager.groups.GroupPermission;
 import org.asamk.signal.manager.groups.GroupSendingNotAllowedException;
 import org.asamk.signal.manager.groups.LastGroupAdminException;
 import org.asamk.signal.manager.groups.NotAGroupMemberException;
+import org.asamk.signal.manager.storage.SignalAccount;
 import org.asamk.signal.manager.storage.recipients.Contact;
 import org.asamk.signal.manager.storage.recipients.Profile;
 import org.asamk.signal.manager.storage.recipients.RecipientAddress;
@@ -77,6 +78,11 @@ public class DbusManagerImpl implements Manager {
 
     @Override
     public void checkAccountState() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SignalAccount getAccount() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/asamk/signal/dbus/DbusSignalControlImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusSignalControlImpl.java
@@ -1,36 +1,65 @@
 package org.asamk.signal.dbus;
 
 import org.asamk.SignalControl;
+import org.asamk.SignalControl.Error;
+import org.asamk.signal.App;
 import org.asamk.signal.BaseConfig;
 import org.asamk.signal.DbusConfig;
+import org.asamk.signal.DbusReceiveMessageHandler;
+import org.asamk.signal.JsonDbusReceiveMessageHandler;
+import org.asamk.signal.JsonWriter;
+import org.asamk.signal.OutputWriter;
+import org.asamk.signal.PlainTextWriter;
+import org.asamk.signal.commands.DaemonCommand;
 import org.asamk.signal.commands.SignalCreator;
+import org.asamk.signal.commands.exceptions.CommandException;
 import org.asamk.signal.manager.Manager;
 import org.asamk.signal.manager.ProvisioningManager;
 import org.asamk.signal.manager.RegistrationManager;
 import org.asamk.signal.manager.UserAlreadyExists;
+import org.asamk.signal.manager.config.ServiceEnvironment;
+import org.asamk.signal.manager.storage.identities.TrustNewIdentity;
+
 import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.whispersystems.libsignal.util.Pair;
 import org.whispersystems.signalservice.api.KeyBackupServicePinException;
 import org.whispersystems.signalservice.api.KeyBackupSystemNoDataException;
 import org.whispersystems.signalservice.api.push.exceptions.CaptchaRequiredException;
 import org.whispersystems.signalservice.api.util.PhoneNumberFormatter;
 
+import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URI;
+import java.nio.channels.OverlappingFileLockException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class DbusSignalControlImpl implements org.asamk.SignalControl {
 
-    private final SignalCreator c;
-    private final Function<Manager, Thread> newManagerRunner;
+    private static SignalCreator c;
+    private static Function<Manager, Thread> newManagerRunner;
 
-    private final List<Pair<Manager, Thread>> receiveThreads = new ArrayList<>();
-    private final Object stopTrigger = new Object();
-    private final String objectPath;
+    private static List<Pair<Manager, Thread>> receiveThreads = new ArrayList<>();
+    private static Object stopTrigger = new Object();
+    private static String objectPath;
+    private static DBusConnection.DBusBusType busType;
+    public static RegistrationManager registrationManager;
+    public static ProvisioningManager provisioningManager;
+
+    private final static Logger logger = LoggerFactory.getLogger(DbusSignalControlImpl.class);
 
     public DbusSignalControlImpl(
             final SignalCreator c, final Function<Manager, Thread> newManagerRunner, final String objectPath
@@ -38,9 +67,10 @@ public class DbusSignalControlImpl implements org.asamk.SignalControl {
         this.c = c;
         this.newManagerRunner = newManagerRunner;
         this.objectPath = objectPath;
+        this.busType = busType;
     }
 
-    public void addManager(Manager m) {
+    public static void addManager(Manager m) {
         var thread = newManagerRunner.apply(m);
         if (thread == null) {
             return;
@@ -125,7 +155,9 @@ public class DbusSignalControlImpl implements org.asamk.SignalControl {
     ) throws Error.Failure, Error.InvalidNumber {
         try (final RegistrationManager registrationManager = c.getNewRegistrationManager(number)) {
             final Manager manager = registrationManager.verifyAccount(verificationCode, pin);
+            logger.info("Registration of " + number + " verified");
             addManager(manager);
+            registrationManager.close();
         } catch (IOException | KeyBackupSystemNoDataException | KeyBackupServicePinException e) {
             throw new SignalControl.Error.Failure(e.getClass().getSimpleName() + " " + e.getMessage());
         }
@@ -139,9 +171,19 @@ public class DbusSignalControlImpl implements org.asamk.SignalControl {
             new Thread(() -> {
                 try {
                     final Manager manager = provisioningManager.finishDeviceLink(newDeviceName);
+                    logger.info("Linking of " + newDeviceName + " successful");
                     addManager(manager);
-                } catch (IOException | TimeoutException | UserAlreadyExists e) {
-                    e.printStackTrace();
+                    //no need to close provisioningManager; it cleaned up during finishDeviceLink
+                } catch (TimeoutException e) {
+                    throw new SignalControl.Error.Failure(e.getClass().getSimpleName() + ": Link request timed out, please try again.");
+                } catch (IOException e) {
+                    throw new SignalControl.Error.Failure(e.getClass().getSimpleName() + ": Link request error: " + e.getMessage());
+                } catch (UserAlreadyExists e) {
+                    throw new SignalControl.Error.Failure(e.getClass().getSimpleName() + ": The user "
+                            + e.getNumber()
+                            + " already exists\nDelete \""
+                            + e.getFileName()
+                            + "\" before trying again.");
                 }
             }).start();
             return deviceLinkUri.toString();
@@ -153,6 +195,51 @@ public class DbusSignalControlImpl implements org.asamk.SignalControl {
     @Override
     public String version() {
         return BaseConfig.PROJECT_VERSION;
+    }
+
+    @Override
+    public void listen(String number) {
+        try {
+            File settingsPath = c.getSettingsPath();
+            List<String> usernames = Manager.getAllLocalNumbers(settingsPath);
+            if (!usernames.contains(number)) {
+                throw new Error.Failure("Listen: " + number + " is not registered.");
+            }
+            String objectPath = DbusConfig.getObjectPath(number);
+            DBusConnection.DBusBusType busType = DaemonCommand.dBusType;
+            ServiceEnvironment serviceEnvironment = c.getServiceEnvironment();
+            TrustNewIdentity trustNewIdentity = DaemonCommand.trustNewIdentity;
+
+            //create new manager for this number
+            final Manager m = App.loadManager(number, settingsPath, serviceEnvironment, trustNewIdentity);
+            addManager(m);
+            final var thread = new Thread(() -> {
+                try {
+                    OutputWriter outputWriter = DaemonCommand.outputWriter;
+                    boolean ignoreAttachments = false;
+                    DBusConnection conn = DBusConnection.getConnection(busType);
+                    while (!Thread.interrupted()) {
+                        try {
+                            final var receiveMessageHandler = outputWriter instanceof JsonWriter
+                                    ? new JsonDbusReceiveMessageHandler(m, (JsonWriter) outputWriter, conn, objectPath)
+                                    : new DbusReceiveMessageHandler(m, (PlainTextWriter) outputWriter, conn, objectPath);
+                            m.receiveMessages(1, TimeUnit.HOURS, false, ignoreAttachments, receiveMessageHandler);
+                            break;
+                        } catch (IOException e) {
+                            logger.warn("Receiving messages failed, retrying", e);
+                        }
+                    }
+                } catch (DBusException e) {
+                    throw new Error.Failure(e.getClass().getSimpleName() + " Listen error: " + e.getMessage());
+                }
+            });
+        } catch (OverlappingFileLockException e) {
+            logger.warn("Ignoring {}: {}", number, e.getMessage());
+            throw new Error.Failure(e.getClass().getSimpleName() + " Already listening: " + e.getMessage());
+        } catch (CommandException e) {
+            logger.warn("Ignoring {}: {}", number, e.getMessage());
+            throw new Error.Failure(e.getClass().getSimpleName() + " Listen error: " + e.getMessage());
+        }
     }
 
     @Override


### PR DESCRIPTION
This request adds new DBus functionality with `listen` and `unlisten` methods. It also handles FileLocks better so as to permit multiple instances of `signal-cli` to run concurrently handling different accounts (phone numbers) on different instances. Currently, I have tested it with two instances, one on the default system bus and a second on the session bus. 

These rely on the "anonymous" DBus daemon (as opposed to the daemon where a `-u username` is specified). In the default case, it behaves exactly as it has before: `signal-cli daemon` exports all local numbers.

But with the new `--number` option (or its synonym `--numbers`), it's possible to specify which accounts are exported on startup, and then later add and remove accounts (using `listen` and `unlisten`). In the simplest case, the daemon is started with no accounts exported: `signal-cli daemon --number`

The `unregister` method also has an optional boolean to retain the user's data; setting this to `false` erases the account information in the local data directory (normally $HOME/.local/share/signal-cli/data). 

This addresses two issues previously raised:
- "losing" messages when the daemon is started. By starting in anonymous mode with no accounts exported, the messages remain on the Signal server until the `listen` method is called. Therefore, no messages are lost.
- "locking out" accounts from the session bus when they are already exported on the system bus (or vice versa). Now the user can unlisten on one bus and then listen on the other.
