### PR TITLE
change received messages to be JsonRpcResponses instead of requests

### DIFF
--- a/src/main/java/org/asamk/signal/commands/JsonRpcDispatcherCommand.java
+++ b/src/main/java/org/asamk/signal/commands/JsonRpcDispatcherCommand.java
@@ -71,9 +71,9 @@ public class JsonRpcDispatcherCommand implements LocalCommand {
         final var jsonRpcSender = new JsonRpcSender((JsonWriter) outputWriter);
 
         final var receiveMessageHandler = new JsonReceiveMessageHandler(m,
-                s -> jsonRpcSender.sendRequest(JsonRpcRequest.forNotification("receive",
+                s -> jsonRpcSender.sendResponse(JsonRpcResponse.forSuccess(
                         objectMapper.valueToTree(s),
-                        null)));
+                        objectMapper.valueToTree("receive"))));
         m.addReceiveHandler(receiveMessageHandler);
 
         // Maybe this should be handled inside the Manager


### PR DESCRIPTION
It can be unexpected to receive Requests from jsonrpc server. This changes received messages to be Responses, with an id of "receive". The spec doesn't say you can't send Responses without a Request. 