### PR TITLE
create inet socket with wildcard address

### DIFF
--- a/src/main/java/org/asamk/signal/util/IOUtils.java
+++ b/src/main/java/org/asamk/signal/util/IOUtils.java
@@ -107,7 +107,9 @@ public class IOUtils {
         } catch (NumberFormatException e) {
             throw new UserErrorException("Invalid tcp bind address: " + tcpAddress, e);
         }
-        return new InetSocketAddress(host, port);
+        return "*".equals(host) 
+          ? new InetSocketAddress(port)
+          : new InetSocketAddress(host, port);
     }
 
     public static UnixDomainPrincipal getUnixDomainPrincipal(final SocketChannel channel) throws IOException {


### PR DESCRIPTION
To run signal-cli within a docker container it is much easier with a wildcard address. 

parameter `--tcp *:7583`

I just startet to create a  "docker-signal-cli" repository, https://github.com/thorsten-l/docker-signal-cli,
running signal-cli within a docker container as a daemon.
