### PR TITLE
add isRegistered to SignalControl

### DIFF
--- a/src/main/java/org/asamk/SignalControl.java
+++ b/src/main/java/org/asamk/SignalControl.java
@@ -16,6 +16,8 @@ public interface SignalControl extends DBusInterface {
             String number, boolean voiceVerification
     ) throws Error.Failure, Error.InvalidNumber, Error.RequiresCaptcha;
 
+    boolean isRegistered();
+
     void registerWithCaptcha(
             String number, boolean voiceVerification, String captcha
     ) throws Error.Failure, Error.InvalidNumber, Error.RequiresCaptcha;

--- a/src/main/java/org/asamk/signal/dbus/DbusSignalControlImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusSignalControlImpl.java
@@ -48,6 +48,11 @@ public class DbusSignalControlImpl implements org.asamk.SignalControl {
     }
 
     @Override
+    public boolean isRegistered() {
+        return false;
+    }
+
+    @Override
     public void registerWithCaptcha(
             final String number, final boolean voiceVerification, final String captcha
     ) throws Error.Failure, Error.InvalidNumber {


### PR DESCRIPTION
To make the use of isRegistered() consistant between DbusSignal (always returns true) add a method that always returns false to DbusSignalControl.

This enables clients to easily distinguish what they're talking to
