### PR TITLE
Added needed step for a native binary build

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ work in all situations.
 
 1. [Install GraalVM and setup the enviroment](https://www.graalvm.org/docs/getting-started/#install-graalvm)
 2. [Install prerequisites](https://www.graalvm.org/reference-manual/native-image/#prerequisites)
-3. Execute Gradle:
+3. Copy the libsignal_jni.so to the `lib/src/main/resources/` directory 
+4. Execute Gradle:
 
         ./gradlew nativeCompile
 


### PR DESCRIPTION
The libsignal_jni.so must be placed to the lib/src/main/resources/ directory to included in the native binary.