### PR TITLE
Set security options for the example signal-cli-socket systemd unit

### DIFF
--- a/data/signal-cli-socket.service
+++ b/data/signal-cli-socket.service
@@ -5,15 +5,42 @@ After=network-online.target
 Requires=signal-cli-socket.socket
 
 [Service]
-Type=simple
+CapabilityBoundingSet=
 Environment="SIGNAL_CLI_OPTS=-Xms2m"
-ExecStart=%dir%/bin/signal-cli --config /var/lib/signal-cli daemon
-User=signal-cli
+# Update 'ReadWritePaths' if you change the config path here
+ExecStart=/usr/local/bin/signal-cli --config /var/lib/signal-cli daemon
+LockPersonality=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateIPC=true
+PrivateTmp=true
+PrivateUsers=true
+ProcSubset=pid
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=strict
+# Profile pictures and attachments to upload must be located here for the service to access them
+ReadWritePaths=/var/lib/signal-cli
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
 # JVM always exits with 143 in reaction to SIGTERM signal
 SuccessExitStatus=143
 StandardInput=socket
 StandardOutput=journal
 StandardError=journal
+SystemCallArchitectures=native
+SystemCallFilter=~@debug @mount @obsolete @privileged @resources
+UMask=0077
+# Create the user and home directory with 'useradd -r -U -s /usr/sbin/nologin -m -b /var/lib signal-cli'
+User=signal-cli
 
 [Install]
 Also=signal-cli-socket.socket

--- a/data/signal-cli-socket.service
+++ b/data/signal-cli-socket.service
@@ -8,7 +8,7 @@ Requires=signal-cli-socket.socket
 CapabilityBoundingSet=
 Environment="SIGNAL_CLI_OPTS=-Xms2m"
 # Update 'ReadWritePaths' if you change the config path here
-ExecStart=/usr/local/bin/signal-cli --config /var/lib/signal-cli daemon
+ExecStart=%dir%/bin/signal-cli --config /var/lib/signal-cli daemon
 LockPersonality=true
 NoNewPrivileges=true
 PrivateDevices=true

--- a/data/signal-cli-socket.service
+++ b/data/signal-cli-socket.service
@@ -27,6 +27,7 @@ ProtectProc=invisible
 ProtectSystem=strict
 # Profile pictures and attachments to upload must be located here for the service to access them
 ReadWritePaths=/var/lib/signal-cli
+RemoveIPC=true
 RestrictAddressFamilies=AF_INET AF_INET6
 RestrictNamespaces=true
 RestrictRealtime=true

--- a/data/signal-cli-socket.socket
+++ b/data/signal-cli-socket.socket
@@ -3,6 +3,11 @@ Description=Send secure messages to Signal clients
 
 [Socket]
 ListenStream=%t/signal-cli/socket
+SocketUser=root
+# Add yourself to the signal-cli group to talk with the service
+# Run 'usermod -aG signal-cli yourusername'
+SocketGroup=signal-cli
+SocketMode=0660
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
This pull request restricts the execution environment of signal-cli (in socket mode) to make it more difficult to compromise rest of the system in case the daemon is compromised, while retaining functionality. Mainly:
1. No access to home directories
2. Read only root file system
3. Private /tmp directory
4. No access to /proc except own process
5. Socket restricted to root and users of the signal-cli group
6. Blacklist unused system calls