### PR TITLE
add org.whispersystems.signalservice.internal.push.SignalServiceProtos.storyContext_ to graalvm reflect config

### DIFF
--- a/graalvm-config-dir/reflect-config.json
+++ b/graalvm-config-dir/reflect-config.json
@@ -2347,6 +2347,7 @@
     {"name":"reaction_"}, 
     {"name":"requiredProtocolVersion_"}, 
     {"name":"sticker_"}, 
+    {"name":"storyContext_"}, 
     {"name":"timestamp_"}
   ]}
 ,


### PR DESCRIPTION
When trying to call DBus `createGroup()`, native graalvm build is missing `org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.storyContext_`.

```
>>> from pydbus import SystemBus; bus = SystemBus(); signal = bus.get("org.asamk.Signal", "/org/asamk/Signal/ACCOUNT")
>>> signal.version()
'0.10.2'
>>> signal.createGroup("DBusGroup", ["MEMBER"], "")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/var/lib/signal-cli/venv/lib/python3.8/site-packages/pydbus/proxy_method.py", line 72, in __call__
    ret = instance._bus.con.call_sync(
gi.repository.GLib.GError: g-io-error-quark: GDBus.Error:org.freedesktop.dbus.exceptions.DBusExecutionException: Error Executing Method org.asamk.Signal.createGroup: Field storyContext_ for org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage not found. Known fields are [private int org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.bitField0_, private java.lang.String org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.body_, private com.google.protobuf.Internal$ProtobufList org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.attachments_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$GroupContext org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.group_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$GroupContextV2 org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.groupV2_, private int org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.flags_, private int org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.expireTimer_, private com.google.protobuf.ByteString org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.profileKey_, private long org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.timestamp_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Quote org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.quote_, private com.google.protobuf.Internal$ProtobufList org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.contact_, private com.google.protobuf.Internal$ProtobufList org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.preview_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Sticker org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.sticker_, private int org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.requiredProtocolVersion_, private boolean org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.isViewOnce_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Reaction org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.reaction_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Delete org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.delete_, private com.google.protobuf.Internal$ProtobufList org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.bodyRanges_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$GroupCallUpdate org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.groupCallUpdate_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Payment org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.payment_] (36)

g-io-error-quark: GDBus.Error:org.freedesktop.dbus.exceptions.DBusExecutionException: Error Executing Method org.asamk.Signal.createGroup: Field storyContext_ for org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage not found. Known fields are [private int org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.bitField0_, private java.lang.String org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.body_, private com.google.protobuf.Internal$ProtobufList org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.attachments_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$GroupContext org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.group_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$GroupContextV2 org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.groupV2_, private int org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.flags_, private int org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.expireTimer_, private com.google.protobuf.ByteString org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.profileKey_, private long org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.timestamp_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Quote org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.quote_, private com.google.protobuf.Internal$ProtobufList org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.contact_, private com.google.protobuf.Internal$ProtobufList org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.preview_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Sticker org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.sticker_, private int org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.requiredProtocolVersion_, private boolean org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.isViewOnce_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Reaction org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.reaction_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Delete org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.delete_, private com.google.protobuf.Internal$ProtobufList org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.bodyRanges_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$GroupCallUpdate org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.groupCallUpdate_, private org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage$Payment org.whispersystems.signalservice.internal.push.SignalServiceProtos$DataMessage.payment_] (36)
```

@bbernhard might be interesting for you too.

Signed-off-by: morph027 <stefan.heitmueller@gmx.com>