### PR TITLE
Added base64 encoded attachment support

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/helper/AttachmentHelper.java
+++ b/lib/src/main/java/org/asamk/signal/manager/helper/AttachmentHelper.java
@@ -51,7 +51,7 @@ public class AttachmentHelper {
     }
 
     public SignalServiceAttachmentPointer uploadAttachment(String attachment) throws IOException, AttachmentInvalidException {
-        var attachmentStream = AttachmentUtils.createAttachmentStream(new File(attachment));
+        var attachmentStream = AttachmentUtils.createAttachmentStream(attachment);
         return uploadAttachment(attachmentStream);
     }
 

--- a/lib/src/main/java/org/asamk/signal/manager/util/AttachmentUtils.java
+++ b/lib/src/main/java/org/asamk/signal/manager/util/AttachmentUtils.java
@@ -6,6 +6,7 @@ import org.whispersystems.signalservice.api.util.StreamDetails;
 import org.whispersystems.signalservice.internal.push.http.ResumableUploadSpec;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,17 +20,21 @@ public class AttachmentUtils {
         }
         final var signalServiceAttachments = new ArrayList<SignalServiceAttachmentStream>(attachments.size());
         for (var attachment : attachments) {
-            signalServiceAttachments.add(createAttachmentStream(new File(attachment)));
+            signalServiceAttachments.add(createAttachmentStream(attachment));
         }
         return signalServiceAttachments;
     }
 
-    public static SignalServiceAttachmentStream createAttachmentStream(File attachmentFile) throws AttachmentInvalidException {
+    public static SignalServiceAttachmentStream createAttachmentStream(String attachment) throws AttachmentInvalidException {
         try {
-            final var streamDetails = Utils.createStreamDetailsFromFile(attachmentFile);
-            return createAttachmentStream(streamDetails, Optional.of(attachmentFile.getName()));
+            final var streamDetails = Utils.createStreamDetails(attachment);
+            final var name = streamDetails.getStream() instanceof FileInputStream
+                    ? new File(attachment).getName()
+                    : null;
+
+            return createAttachmentStream(streamDetails, Optional.ofNullable(name));
         } catch (IOException e) {
-            throw new AttachmentInvalidException(attachmentFile.toString(), e);
+            throw new AttachmentInvalidException(attachment, e);
         }
     }
 

--- a/lib/src/main/java/org/asamk/signal/manager/util/AttachmentUtils.java
+++ b/lib/src/main/java/org/asamk/signal/manager/util/AttachmentUtils.java
@@ -28,11 +28,8 @@ public class AttachmentUtils {
     public static SignalServiceAttachmentStream createAttachmentStream(String attachment) throws AttachmentInvalidException {
         try {
             final var streamDetails = Utils.createStreamDetails(attachment);
-            final var name = streamDetails.getStream() instanceof FileInputStream
-                    ? new File(attachment).getName()
-                    : null;
 
-            return createAttachmentStream(streamDetails, Optional.ofNullable(name));
+            return createAttachmentStream(streamDetails.first(), streamDetails.second());
         } catch (IOException e) {
             throw new AttachmentInvalidException(attachment, e);
         }

--- a/lib/src/main/java/org/asamk/signal/manager/util/DataURI.java
+++ b/lib/src/main/java/org/asamk/signal/manager/util/DataURI.java
@@ -1,0 +1,64 @@
+package org.asamk.signal.manager.util;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Data URI record that follows RFC 2397.
+ *
+ * @param mediaType the media type. If empty, the default media type "text/plain" is used.
+ * @param parameter the list of parameters. Must be URL escaped encoded.
+ * @param data      the data. If base64 is not given, the data is treated as ASCII string.
+ */
+@SuppressWarnings({"java:S6218"})
+public record DataURI(String mediaType, Map<String, String> parameter, byte[] data) {
+
+    public static final Pattern DATA_URI_PATTERN = Pattern.compile(
+            "data:(?<type>.+?\\/.+?)?(?<parameters>;.+?)?(?<base64>;base64)?,(?<data>.+)",
+            Pattern.CASE_INSENSITIVE);
+    public static final Pattern PARAMETER_PATTERN = Pattern.compile("\\G;(?<key>.+)=(?<value>.+)",
+            Pattern.CASE_INSENSITIVE);
+    public static final String DEFAULT_TYPE = "text/plain";
+
+    /**
+     * Generates a new {@link DataURI} object from the given string.
+     *
+     * @param dataURI the data URI
+     * @return a data URI object
+     * @throws IllegalArgumentException if the given string is not a valid data URI
+     */
+    public static DataURI of(final String dataURI) {
+        final var matcher = DATA_URI_PATTERN.matcher(dataURI);
+
+        if (!matcher.find()) {
+            throw new IllegalArgumentException("The given string is not a valid data URI.");
+        }
+
+        final Map<String, String> parameters = new HashMap<>();
+        final var params = matcher.group("parameters");
+        if (params != null) {
+            final Matcher paramsMatcher = PARAMETER_PATTERN.matcher(params);
+            while (paramsMatcher.find()) {
+                final var key = paramsMatcher.group("key");
+                final var value = URLDecoder.decode(paramsMatcher.group("value"), StandardCharsets.UTF_8);
+                parameters.put(key, value);
+            }
+        }
+
+        final boolean isBase64 = matcher.group("base64") != null;
+        final byte[] data;
+        if (isBase64) {
+            data = Base64.getDecoder().decode(matcher.group("data").getBytes(StandardCharsets.UTF_8));
+        } else {
+            data = URLDecoder.decode(matcher.group("data"), StandardCharsets.UTF_8).getBytes(StandardCharsets.UTF_8);
+        }
+
+        return new DataURI(Optional.ofNullable(matcher.group("type")).orElse(DEFAULT_TYPE), parameters, data);
+    }
+}

--- a/lib/src/main/java/org/asamk/signal/manager/util/DataURI.java
+++ b/lib/src/main/java/org/asamk/signal/manager/util/DataURI.java
@@ -9,25 +9,31 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * Data URI record that follows RFC 2397.
- *
- * @param mediaType the media type. If empty, the default media type "text/plain" is used.
- * @param parameter the list of parameters. Must be URL escaped encoded.
- * @param data      the data. If base64 is not given, the data is treated as ASCII string.
- */
 @SuppressWarnings({"java:S6218"})
 public record DataURI(String mediaType, Map<String, String> parameter, byte[] data) {
 
     public static final Pattern DATA_URI_PATTERN = Pattern.compile(
-            "data:(?<type>.+?\\/.+?)?(?<parameters>;.+?)?(?<base64>;base64)?,(?<data>.+)",
+            "\\Adata:(?<type>.+?/.+?)?(?<parameters>;.+?=.+?)?(?<base64>;base64)?,(?<data>.+)\\z",
             Pattern.CASE_INSENSITIVE);
     public static final Pattern PARAMETER_PATTERN = Pattern.compile("\\G;(?<key>.+)=(?<value>.+)",
             Pattern.CASE_INSENSITIVE);
     public static final String DEFAULT_TYPE = "text/plain";
 
     /**
-     * Generates a new {@link DataURI} object from the given string.
+     * Generates a new {@link DataURI} object that follows
+     * <a href="https://datatracker.ietf.org/doc/html/rfc2397">RFC 2397</a> from the given string.
+     * <p>
+     * The {@code dataURI} must be of the form:
+     * <p>
+     * {@code
+     * data:[<mediatype>][;base64],<data>
+     * }
+     * <p>
+     * The {@code <mediatype>} is an Internet media type specification (with
+     * optional parameters.) The appearance of ";base64" means that the data
+     * is encoded as base64. Without ";base64", the data is represented using (ASCII) URL Escaped encoding.
+     * If {@code <mediatype>} is omitted, it defaults to {@link DataURI#DEFAULT_TYPE}.
+     * Parameter values should use the URL Escaped encoding.
      *
      * @param dataURI the data URI
      * @return a data URI object

--- a/lib/src/main/java/org/asamk/signal/manager/util/Utils.java
+++ b/lib/src/main/java/org/asamk/signal/manager/util/Utils.java
@@ -46,25 +46,25 @@ public class Utils {
         return mime;
     }
 
-    private static boolean isBase64DataString(String[] parts) {
+    private static boolean isBase64DataString(final String[] parts) {
         return parts.length == 2
                 && parts[0].startsWith("data:")
                 && parts[0].contains("/")
                 && parts[1].startsWith("base64,");
     }
 
-    public static boolean isBase64DataString(String value) {
+    public static boolean isBase64DataString(final String value) {
         return isBase64DataString(value.split(";", 2));
     }
 
-    public static StreamDetails createStreamDetailsFromBase64(String base64) {
+    public static StreamDetails createStreamDetailsFromBase64(final String base64) {
         final String[] parts = base64.split(";", 2);
         if (!isBase64DataString(parts)) {
             throw new IllegalArgumentException("The given argument is not a valid base64 string.");
         }
 
         parts[0] = parts[0].substring(5);
-        byte[] bytes = Base64.getDecoder().decode(parts[1].substring(7).getBytes(StandardCharsets.UTF_8));
+        final byte[] bytes = Base64.getDecoder().decode(parts[1].substring(7).getBytes(StandardCharsets.UTF_8));
 
         return new StreamDetails(new ByteArrayInputStream(bytes), parts[0], bytes.length);
     }
@@ -76,7 +76,7 @@ public class Utils {
         return new StreamDetails(stream, mime, size);
     }
 
-    public static StreamDetails createStreamDetails(String value) throws IOException {
+    public static StreamDetails createStreamDetails(final String value) throws IOException {
         if (isBase64DataString(value)) {
             return createStreamDetailsFromBase64(value);
         }

--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -231,7 +231,7 @@ Read the message from standard input.
 
 *-a* [ATTACHMENT [ATTACHMENT ...]], *--attachment* [ATTACHMENT [ATTACHMENT ...]]::
 Add one or more files as attachment.
-Data URI encoded attachments can be added and must follow the RFC 2397.
+Can be either a file path or a data URI. Data URI encoded attachments must follow the RFC 2397.
 Additionally a file name can be added:
 e.g.: `data:<MIME-TYPE>;filename=<FILENAME>;base64,<BASE64 ENCODED DATA>`
 

--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -231,6 +231,9 @@ Read the message from standard input.
 
 *-a* [ATTACHMENT [ATTACHMENT ...]], *--attachment* [ATTACHMENT [ATTACHMENT ...]]::
 Add one or more files as attachment.
+Data URI encoded attachments can be added and must follow the RFC 2397.
+Additionally a file name can be added:
+e.g.: `data:<MIME-TYPE>;filename=<FILENAME>;base64,<BASE64 ENCODED DATA>`
 
 *--sticker* STICKER::
 Send a sticker of a locally known sticker pack (syntax: stickerPackId:stickerId).

--- a/src/main/java/org/asamk/signal/commands/SendCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendCommand.java
@@ -55,7 +55,9 @@ public class SendCommand implements JsonRpcLocalCommand {
         mut.addArgument("--message-from-stdin")
                 .action(Arguments.storeTrue())
                 .help("Read the message from standard input.");
-        subparser.addArgument("-a", "--attachment").nargs("*").help("Add file as attachment");
+        subparser.addArgument("-a", "--attachment").nargs("*").help("Add file as attachment."
+                + "Base64 encoded attachments can be added and must follow the format "
+                + "data:<MIME-TYPE>;base64,<BASE64 ENCODED DATA>.");
         subparser.addArgument("-e", "--end-session", "--endsession")
                 .help("Clear session state and send end session message.")
                 .action(Arguments.storeTrue());

--- a/src/main/java/org/asamk/signal/commands/SendCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendCommand.java
@@ -56,8 +56,8 @@ public class SendCommand implements JsonRpcLocalCommand {
                 .action(Arguments.storeTrue())
                 .help("Read the message from standard input.");
         subparser.addArgument("-a", "--attachment").nargs("*").help("Add file as attachment."
-                + "Base64 encoded attachments can be added and must follow the format "
-                + "data:<MIME-TYPE>;base64,<BASE64 ENCODED DATA>.");
+                + "Data URI encoded attachments can be added and must follow the RFC 2397. Additionally a file name can be added, e.g. "
+                + "data:<MIME-TYPE>;filename=<FILENAME>;base64,<BASE64 ENCODED DATA>.");
         subparser.addArgument("-e", "--end-session", "--endsession")
                 .help("Clear session state and send end session message.")
                 .action(Arguments.storeTrue());

--- a/src/main/java/org/asamk/signal/commands/SendCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendCommand.java
@@ -55,8 +55,8 @@ public class SendCommand implements JsonRpcLocalCommand {
         mut.addArgument("--message-from-stdin")
                 .action(Arguments.storeTrue())
                 .help("Read the message from standard input.");
-        subparser.addArgument("-a", "--attachment").nargs("*").help("Add file as attachment."
-                + "Data URI encoded attachments can be added and must follow the RFC 2397. Additionally a file name can be added, e.g. "
+        subparser.addArgument("-a", "--attachment").nargs("*").help("Add an attachment. "
+                + "Can be either a file path or a data URI. Data URI encoded attachments must follow the RFC 2397. Additionally a file name can be added, e.g. "
                 + "data:<MIME-TYPE>;filename=<FILENAME>;base64,<BASE64 ENCODED DATA>.");
         subparser.addArgument("-e", "--end-session", "--endsession")
                 .help("Clear session state and send end session message.")


### PR DESCRIPTION
Added support for base64 encoded attachments (see also https://github.com/AsamK/signal-cli/discussions/679#discussioncomment-2871163).

Tested via:

- [X] dbus
- [X] JSON-RPC TCP socket