### PR TITLE
bump user agent version

### DIFF
--- a/src/main/java/org/asamk/signal/BaseConfig.java
+++ b/src/main/java/org/asamk/signal/BaseConfig.java
@@ -5,7 +5,7 @@ public class BaseConfig {
     public final static String PROJECT_NAME = BaseConfig.class.getPackage().getImplementationTitle();
     public final static String PROJECT_VERSION = BaseConfig.class.getPackage().getImplementationVersion();
 
-    final static String USER_AGENT_SIGNAL_ANDROID = "Signal-Android/5.22.3";
+    final static String USER_AGENT_SIGNAL_ANDROID = "Signal-Android/5.52.1";
     final static String USER_AGENT_SIGNAL_CLI = PROJECT_NAME == null
             ? "signal-cli"
             : PROJECT_NAME + "/" + PROJECT_VERSION;


### PR DESCRIPTION
stories dropped and Signal-Android/5.22.3 now seems to get DeprecatedVersionException