### PR TITLE
Change content-type check to check contains

### DIFF
--- a/src/main/java/org/asamk/signal/http/HttpServerHandler.java
+++ b/src/main/java/org/asamk/signal/http/HttpServerHandler.java
@@ -89,7 +89,7 @@ public class HttpServerHandler {
             return;
         }
 
-        if (!"application/json".equals(httpExchange.getRequestHeaders().getFirst("Content-Type"))) {
+        if (!"application/json".contains(httpExchange.getRequestHeaders().getFirst("Content-Type"))) {
             sendResponse(415, null, httpExchange);
             return;
         }

--- a/src/main/java/org/asamk/signal/http/HttpServerHandler.java
+++ b/src/main/java/org/asamk/signal/http/HttpServerHandler.java
@@ -89,7 +89,8 @@ public class HttpServerHandler {
             return;
         }
 
-        if (!"application/json".contains(httpExchange.getRequestHeaders().getFirst("Content-Type"))) {
+        if (httpExchange.getRequestHeaders().getFirst("Content-Type") == null
+                || !httpExchange.getRequestHeaders().getFirst("Content-Type").contains("application/json")) {
             sendResponse(415, null, httpExchange);
             return;
         }


### PR DESCRIPTION
So far it was doing an equals check, but a string like "application/json; charset=utf-8" is similarly valid. And some clients like OkHttp actually automatically add the charset.