### PR TITLE
Fix: Update identities after trust

### DIFF
--- a/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
@@ -1109,6 +1109,7 @@ public class DbusSignalImpl implements Signal {
             } catch (UnregisteredRecipientException e) {
                 throw new Error.Failure("The user " + e.getSender().getIdentifier() + " is not registered.");
             }
+            updateIdentities();
         }
 
         @Override
@@ -1135,6 +1136,7 @@ public class DbusSignalImpl implements Signal {
             } catch (UnregisteredRecipientException e) {
                 throw new Error.Failure("The user " + e.getSender().getIdentifier() + " is not registered.");
             }
+            updateIdentities();
         }
     }
 


### PR DESCRIPTION
While further testing, I discovered that after granting trust, it required a restart to properly reflect this in the properties.
Needed to call updateIdentities() to fix this.

Btw. please take a look at discussion #1263 - I have issues understanding how to interpret safetynumbers between devices.
