### PR TITLE
Do not log to console when outputting as JSON

### DIFF
--- a/src/main/java/org/asamk/signal/Main.java
+++ b/src/main/java/org/asamk/signal/Main.java
@@ -50,7 +50,8 @@ public class Main {
         final var verboseLevel = nsLog == null ? 0 : nsLog.getInt("verbose");
         final var logFile = nsLog == null ? null : nsLog.<File>get("log-file");
         final var scrubLog = nsLog != null && nsLog.getBoolean("scrub-log");
-        configureLogging(verboseLevel, logFile, scrubLog);
+        final var outputType = nsLog == null ? OutputType.PLAIN_TEXT : nsLog.<OutputType>get("output");
+        configureLogging(verboseLevel, logFile, scrubLog, outputType);
 
         var parser = App.buildArgumentParser();
 
@@ -86,6 +87,7 @@ public class Main {
         parser.addArgument("-v", "--verbose").action(Arguments.count());
         parser.addArgument("--log-file").type(File.class);
         parser.addArgument("--scrub-log").action(Arguments.storeTrue());
+        parser.addArgument("-o", "--output").type(Arguments.enumStringType(OutputType.class));
 
         try {
             return parser.parseKnownArgs(args, null);
@@ -94,10 +96,11 @@ public class Main {
         }
     }
 
-    private static void configureLogging(final int verboseLevel, final File logFile, final boolean scrubLog) {
+    private static void configureLogging(final int verboseLevel, final File logFile, final boolean scrubLog, final OutputType outputType) {
         LogConfigurator.setVerboseLevel(verboseLevel);
         LogConfigurator.setLogFile(logFile);
         LogConfigurator.setScrubSensitiveInformation(scrubLog);
+        LogConfigurator.setOutputType(outputType == null ? OutputType.PLAIN_TEXT : outputType);
 
         if (verboseLevel > 0) {
             java.util.logging.Logger.getLogger("")

--- a/src/main/java/org/asamk/signal/logging/LogConfigurator.java
+++ b/src/main/java/org/asamk/signal/logging/LogConfigurator.java
@@ -1,5 +1,7 @@
 package org.asamk.signal.logging;
 
+import org.asamk.signal.OutputType;
+
 import java.io.File;
 
 import ch.qos.logback.classic.Level;
@@ -21,6 +23,7 @@ public class LogConfigurator extends ContextAwareBase implements Configurator {
     private static int verboseLevel = 0;
     private static File logFile = null;
     private static boolean scrubSensitiveInformation = false;
+    private static OutputType outputType = OutputType.PLAIN_TEXT;
 
     public static void setVerboseLevel(int verboseLevel) {
         LogConfigurator.verboseLevel = verboseLevel;
@@ -34,6 +37,10 @@ public class LogConfigurator extends ContextAwareBase implements Configurator {
         LogConfigurator.scrubSensitiveInformation = scrubSensitiveInformation;
     }
 
+    public static void setOutputType(final OutputType outputType) {
+        LogConfigurator.outputType = outputType;
+    }
+
     @Override
     public ExecutionStatus configure(LoggerContext lc) {
         final var rootLogger = lc.getLogger(Logger.ROOT_LOGGER_NAME);
@@ -45,7 +52,10 @@ public class LogConfigurator extends ContextAwareBase implements Configurator {
                 ? createSimpleLoggingLayout(lc)
                 : createDetailedLoggingLayout(lc);
         final var consoleAppender = createLoggingConsoleAppender(lc, createLayoutWrappingEncoder(consoleLayout));
-        rootLogger.addAppender(consoleAppender);
+
+        if(outputType == OutputType.PLAIN_TEXT) {
+            rootLogger.addAppender(consoleAppender);
+        }
 
         lc.getLogger("org.asamk").setLevel(verboseLevel > 1 ? Level.ALL : verboseLevel > 0 ? Level.DEBUG : Level.INFO);
         lc.getLogger("com.zaxxer.hikari.pool.PoolBase")
@@ -53,7 +63,7 @@ public class LogConfigurator extends ContextAwareBase implements Configurator {
         lc.getLogger("org.sqlite.core.NativeDB")
                 .setLevel(verboseLevel > 3 ? Level.ALL : verboseLevel > 1 ? Level.INFO : Level.WARN);
 
-        if (logFile != null) {
+        if (logFile != null && outputType != OutputType.PLAIN_TEXT) {
             consoleAppender.addFilter(new Filter<>() {
                 @Override
                 public FilterReply decide(final ILoggingEvent event) {


### PR DESCRIPTION
The default logging behavior and format can cause issues when the output format is JSON, [as apparent in this issue in signal-cli-rest-api.](https://github.com/bbernhard/signal-cli-rest-api/issues/407) This PR changes the logging behavior so that if the output type is JSON, log messages won't be printed to the console (but still can be viewed using the log file)

Result:
```sh
$ ./signal-cli version 
WARN  MultiAccountManager - Ignoring +48123456789: User is not registered. (NotRegisteredException)
signal-cli 0.12.4

$ ./signal-cli --log-file log.txt -o json version
{"version":"0.12.4"}

$ cat log.txt
2023-10-28T18:28:05.124+0200 [main] WARN  o.a.s.manager.MultiAccountManager - Ignoring +48123456789: User is not registered. (NotRegisteredException)
```