### PR TITLE
Add group name and timestamps on json message

### DIFF
--- a/src/main/java/org/asamk/signal/json/JsonDataMessage.java
+++ b/src/main/java/org/asamk/signal/json/JsonDataMessage.java
@@ -2,6 +2,7 @@ package org.asamk.signal.json;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import org.asamk.signal.manager.Manager;
 import org.asamk.signal.manager.api.MessageEnvelope;
 
 import java.util.List;
@@ -25,10 +26,10 @@ record JsonDataMessage(
         @JsonInclude(JsonInclude.Include.NON_NULL) JsonStoryContext storyContext
 ) {
 
-    static JsonDataMessage from(MessageEnvelope.Data dataMessage) {
+    static JsonDataMessage from(MessageEnvelope.Data dataMessage, Manager m) {
         final var timestamp = dataMessage.timestamp();
         final var groupInfo = dataMessage.groupContext().isPresent() ? JsonGroupInfo.from(dataMessage.groupContext()
-                .get()) : null;
+                .get(), m) : null;
         final var storyContext = dataMessage.storyContext().isPresent()
                 ? JsonStoryContext.from(dataMessage.storyContext().get())
                 : null;

--- a/src/main/java/org/asamk/signal/json/JsonEditMessage.java
+++ b/src/main/java/org/asamk/signal/json/JsonEditMessage.java
@@ -1,10 +1,11 @@
 package org.asamk.signal.json;
 
+import org.asamk.signal.manager.Manager;
 import org.asamk.signal.manager.api.MessageEnvelope;
 
 record JsonEditMessage(long targetSentTimestamp, JsonDataMessage dataMessage) {
 
-    static JsonEditMessage from(MessageEnvelope.Edit editMessage) {
-        return new JsonEditMessage(editMessage.targetSentTimestamp(), JsonDataMessage.from(editMessage.dataMessage()));
+    static JsonEditMessage from(MessageEnvelope.Edit editMessage, Manager m) {
+        return new JsonEditMessage(editMessage.targetSentTimestamp(), JsonDataMessage.from(editMessage.dataMessage(), m));
     }
 }

--- a/src/main/java/org/asamk/signal/json/JsonGroupInfo.java
+++ b/src/main/java/org/asamk/signal/json/JsonGroupInfo.java
@@ -1,11 +1,14 @@
 package org.asamk.signal.json;
 
+import org.asamk.signal.manager.Manager;
 import org.asamk.signal.manager.api.MessageEnvelope;
 
-record JsonGroupInfo(String groupId, String type) {
+record JsonGroupInfo(String groupId, String groupName, int revision, String type) {
 
-    static JsonGroupInfo from(MessageEnvelope.Data.GroupContext groupContext) {
+    static JsonGroupInfo from(MessageEnvelope.Data.GroupContext groupContext, Manager m) {
         return new JsonGroupInfo(groupContext.groupId().toBase64(),
+                m.getGroup(groupContext.groupId()).title(),
+                groupContext.revision(),
                 groupContext.isGroupUpdate() ? "UPDATE" : "DELIVER");
     }
 }

--- a/src/main/java/org/asamk/signal/json/JsonMessageEnvelope.java
+++ b/src/main/java/org/asamk/signal/json/JsonMessageEnvelope.java
@@ -17,6 +17,8 @@ public record JsonMessageEnvelope(
         String sourceName,
         Integer sourceDevice,
         long timestamp,
+        long serverReceivedTimestamp,
+        long serverDeliveredTimestamp,
         @JsonInclude(JsonInclude.Include.NON_NULL) JsonDataMessage dataMessage,
         @JsonInclude(JsonInclude.Include.NON_NULL) JsonEditMessage editMessage,
         @JsonInclude(JsonInclude.Include.NON_NULL) JsonStoryMessage storyMessage,
@@ -58,13 +60,21 @@ public record JsonMessageEnvelope(
             sourceName = null;
         }
         final var timestamp = envelope.timestamp();
+        final var serverReceivedTimestamp = envelope.serverReceivedTimestamp();
+        final var serverDeliveredTimestamp = envelope.serverDeliveredTimestamp();
         final var receiptMessage = envelope.receipt().map(JsonReceiptMessage::from).orElse(null);
         final var typingMessage = envelope.typing().map(JsonTypingMessage::from).orElse(null);
 
-        final var dataMessage = envelope.data().map(JsonDataMessage::from).orElse(null);
-        final var editMessage = envelope.edit().map(JsonEditMessage::from).orElse(null);
+        final var dataMessage = envelope.data()
+            .map(data -> JsonDataMessage.from(data, m))
+            .orElse(null);
+        final var editMessage = envelope.edit()
+            .map(data -> JsonEditMessage.from(data, m))
+            .orElse(null);
         final var storyMessage = envelope.story().map(JsonStoryMessage::from).orElse(null);
-        final var syncMessage = envelope.sync().map(JsonSyncMessage::from).orElse(null);
+        final var syncMessage = envelope.sync()
+            .map(data -> JsonSyncMessage.from(data, m))
+            .orElse(null);
         final var callMessage = envelope.call().map(JsonCallMessage::from).orElse(null);
 
         return new JsonMessageEnvelope(source,
@@ -73,6 +83,8 @@ public record JsonMessageEnvelope(
                 sourceName,
                 sourceDevice,
                 timestamp,
+                serverReceivedTimestamp,
+                serverDeliveredTimestamp,
                 dataMessage,
                 editMessage,
                 storyMessage,

--- a/src/main/java/org/asamk/signal/json/JsonSyncDataMessage.java
+++ b/src/main/java/org/asamk/signal/json/JsonSyncDataMessage.java
@@ -3,6 +3,7 @@ package org.asamk.signal.json;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
+import org.asamk.signal.manager.Manager;
 import org.asamk.signal.manager.api.MessageEnvelope;
 import org.asamk.signal.manager.api.RecipientAddress;
 
@@ -16,13 +17,17 @@ record JsonSyncDataMessage(
         @JsonUnwrapped JsonDataMessage dataMessage
 ) {
 
-    static JsonSyncDataMessage from(MessageEnvelope.Sync.Sent transcriptMessage) {
+    static JsonSyncDataMessage from(MessageEnvelope.Sync.Sent transcriptMessage, Manager m) {
         return new JsonSyncDataMessage(transcriptMessage.destination()
                 .map(RecipientAddress::getLegacyIdentifier)
                 .orElse(null),
                 transcriptMessage.destination().flatMap(RecipientAddress::number).orElse(null),
                 transcriptMessage.destination().flatMap(address -> address.uuid().map(UUID::toString)).orElse(null),
-                transcriptMessage.editMessage().map(JsonEditMessage::from).orElse(null),
-                transcriptMessage.message().map(JsonDataMessage::from).orElse(null));
+                transcriptMessage.editMessage()
+                    .map(data -> JsonEditMessage.from(data, m))
+                    .orElse(null),
+                transcriptMessage.message()
+                    .map(data -> JsonDataMessage.from(data, m))
+                    .orElse(null));
     }
 }

--- a/src/main/java/org/asamk/signal/json/JsonSyncMessage.java
+++ b/src/main/java/org/asamk/signal/json/JsonSyncMessage.java
@@ -2,6 +2,7 @@ package org.asamk.signal.json;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import org.asamk.signal.manager.Manager;
 import org.asamk.signal.manager.api.GroupId;
 import org.asamk.signal.manager.api.MessageEnvelope;
 import org.asamk.signal.manager.api.RecipientAddress;
@@ -23,9 +24,9 @@ record JsonSyncMessage(
         @JsonInclude(JsonInclude.Include.NON_NULL) JsonSyncMessageType type
 ) {
 
-    static JsonSyncMessage from(MessageEnvelope.Sync syncMessage) {
+    static JsonSyncMessage from(MessageEnvelope.Sync syncMessage, Manager m) {
         final var sentMessage = syncMessage.sent().isPresent() && syncMessage.sent().get().story().isEmpty()
-                ? JsonSyncDataMessage.from(syncMessage.sent().get())
+                ? JsonSyncDataMessage.from(syncMessage.sent().get(), m)
                 : null;
         final var sentStoryMessage = syncMessage.sent().isPresent() && syncMessage.sent().get().story().isPresent()
                 ? JsonSyncStoryMessage.from(syncMessage.sent().get())


### PR DESCRIPTION
1. Added functionality to return the group name in JSON output format.
2. Added functionality to return received and delivered timestamps in JSON output format.