### PR TITLE
Fixing RW connections deadlock on SQLite

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/storage/keyValue/KeyValueStore.java
+++ b/lib/src/main/java/org/asamk/signal/manager/storage/keyValue/KeyValueStore.java
@@ -78,7 +78,7 @@ public class KeyValueStore {
             final KeyValueEntry<T> key,
             final T value
     ) throws SQLException {
-        final var entry = getEntry(key);
+        final var entry = getEntry(connection, key);
         if (Objects.equals(entry, value)) {
             return false;
         }


### PR DESCRIPTION
Without this change we're getting a connection in the same thread we hold one already.