### PR TITLE
Fix typo for group-id CLI parameter

### DIFF
--- a/src/main/java/org/asamk/signal/commands/GetAvatarCommand.java
+++ b/src/main/java/org/asamk/signal/commands/GetAvatarCommand.java
@@ -43,7 +43,7 @@ public class GetAvatarCommand implements JsonRpcLocalCommand {
     ) throws CommandException {
         final var contactRecipient = ns.getString("contact");
         final var profileRecipient = ns.getString("profile");
-        final var groupId = ns.getString("groupId");
+        final var groupId = ns.getString("group-id");
 
         final InputStream data;
         try {


### PR DESCRIPTION
## Description
There is a typo in get avatar command for group-id parameter, which causes following error:
```shell
signal-cli -a <phone> getAvatar --group-id <group_id>
java.lang.NullPointerException: Cannot invoke "org.asamk.signal.manager.api.GroupId.toBase64()" because "groupId" is null
        at org.asamk.signal.manager.storage.AvatarStore.getGroupAvatarFile(AvatarStore.java:77)
        at org.asamk.signal.manager.storage.AvatarStore.retrieveGroupAvatar(AvatarStore.java:32)
        at org.asamk.signal.manager.internal.ManagerImpl.retrieveGroupAvatar(ManagerImpl.java:1568)
        at org.asamk.signal.commands.GetAvatarCommand.handleCommand(GetAvatarCommand.java:57)
        at org.asamk.signal.commands.CommandHandler.handleLocalCommand(CommandHandler.java:37)
        at org.asamk.signal.App.handleLocalCommand(App.java:281)
        at org.asamk.signal.App.handleCommand(App.java:182)
        at org.asamk.signal.App.init(App.java:147)
        at org.asamk.signal.Main.main(Main.java:56)
``` 

PR fixes this issue by getting correct parameter from argparse namespace:
```java
public void handleCommand(
        final Namespace ns,
        final Manager m,
        final OutputWriter outputWriter
) throws CommandException {
    ...
    // current: final var groupId = ns.getString("groupId");
    final var groupId = ns.getString("group-id"); // this one is correct
    ...
}
```