### PR TITLE
Print user number in UserAlreadyExistsException DBus error

### DIFF
--- a/src/main/java/org/asamk/signal/dbus/DbusSignalControlImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusSignalControlImpl.java
@@ -145,7 +145,9 @@ public class DbusSignalControlImpl implements org.asamk.SignalControl {
         try {
             final var provisioningManager = c.getProvisioningManagerFor(new URI(deviceLinkUri));
             return provisioningManager.finishDeviceLink(newDeviceName);
-        } catch (TimeoutException | IOException | UserAlreadyExistsException | URISyntaxException e) {
+        } catch (UserAlreadyExistsException e) {
+            throw new SignalControl.Error.Failure(e.getClass().getSimpleName() + " " + e.getNumber());
+        } catch (TimeoutException | IOException | URISyntaxException e) {
             throw new SignalControl.Error.Failure(e.getClass().getSimpleName() + " " + e.getMessage());
         }
     }


### PR DESCRIPTION
Currently, the error looks like "UserAlreadyExistsException null", which does not give enough information to handle this situation in the multi-account daemon mode.

This change adds a phone number to the error message, resolving my issue and achieving functional parity with the CLI interface.