### PR TITLE
Add --ignore-avatars and --ignore-stickers CLI flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Requires libsignal-client version 0.86.12.
 
 - Add sendPollCreate, sendPollVote, sendPollTerminate commands for polls
 - Add updateDevice command to set device name of linked devices
+- Add --ignore-avatars flag to prevent downloading avatars
+- Add --ignore-stickers flag to prevent downloading sticker packs
 
 ### Changed
 

--- a/lib/src/main/java/org/asamk/signal/manager/api/ReceiveConfig.java
+++ b/lib/src/main/java/org/asamk/signal/manager/api/ReceiveConfig.java
@@ -1,3 +1,3 @@
 package org.asamk.signal.manager.api;
 
-public record ReceiveConfig(boolean ignoreAttachments, boolean ignoreStories, boolean sendReadReceipts) {}
+public record ReceiveConfig(boolean ignoreAttachments, boolean ignoreStories, boolean ignoreAvatars, boolean ignoreStickers, boolean sendReadReceipts) {}

--- a/lib/src/main/java/org/asamk/signal/manager/helper/GroupHelper.java
+++ b/lib/src/main/java/org/asamk/signal/manager/helper/GroupHelper.java
@@ -107,7 +107,10 @@ public class GroupHelper {
         return group != null && group.isBlocked();
     }
 
-    public void downloadGroupAvatar(GroupIdV1 groupId, SignalServiceAttachment avatar) {
+    public void downloadGroupAvatar(GroupIdV1 groupId, SignalServiceAttachment avatar, boolean ignoreAvatars) {
+        if (ignoreAvatars) {
+            return;
+        }
         try {
             context.getAvatarStore()
                     .storeGroupAvatar(groupId,
@@ -167,7 +170,7 @@ public class GroupHelper {
                 storeProfileKeysFromMembers(group);
                 final var avatar = group.avatar;
                 if (!avatar.isEmpty()) {
-                    downloadGroupAvatar(groupId, groupSecretParams, avatar);
+                    downloadGroupAvatar(groupId, groupSecretParams, avatar, false);
                 }
             }
             groupInfoV2.setGroup(group);
@@ -506,13 +509,16 @@ public class GroupHelper {
         storeProfileKeysFromMembers(decryptedGroup);
         final var avatar = decryptedGroup.avatar;
         if (!avatar.isEmpty()) {
-            downloadGroupAvatar(groupInfoV2.getGroupId(), groupSecretParams, avatar);
+            downloadGroupAvatar(groupInfoV2.getGroupId(), groupSecretParams, avatar, false);
         }
         groupInfoV2.setGroup(decryptedGroup);
         account.getGroupStore().updateGroup(group);
     }
 
-    private void downloadGroupAvatar(GroupIdV2 groupId, GroupSecretParams groupSecretParams, String cdnKey) {
+    private void downloadGroupAvatar(GroupIdV2 groupId, GroupSecretParams groupSecretParams, String cdnKey, boolean ignoreAvatars) {
+        if (ignoreAvatars) {
+            return;
+        }
         try {
             context.getAvatarStore()
                     .storeGroupAvatar(groupId,

--- a/lib/src/main/java/org/asamk/signal/manager/helper/ProfileHelper.java
+++ b/lib/src/main/java/org/asamk/signal/manager/helper/ProfileHelper.java
@@ -275,10 +275,13 @@ public final class ProfileHelper {
     private Profile decryptProfileAndDownloadAvatar(
             final RecipientId recipientId,
             final ProfileKey profileKey,
-            final SignalServiceProfile encryptedProfile
+            final SignalServiceProfile encryptedProfile,
+            final boolean ignoreAvatars
     ) {
         final var avatarPath = encryptedProfile.getAvatar();
-        downloadProfileAvatar(recipientId, avatarPath, profileKey);
+        if (!ignoreAvatars) {
+            downloadProfileAvatar(recipientId, avatarPath, profileKey, ignoreAvatars);
+        }
 
         return ProfileUtils.decryptProfile(profileKey, encryptedProfile);
     }
@@ -286,8 +289,12 @@ public final class ProfileHelper {
     public void downloadProfileAvatar(
             final RecipientId recipientId,
             final String avatarPath,
-            final ProfileKey profileKey
+            final ProfileKey profileKey,
+            final boolean ignoreAvatars
     ) {
+        if (ignoreAvatars) {
+            return;
+        }
         var profile = account.getProfileStore().getProfile(recipientId);
         if (profile == null || !Objects.equals(avatarPath, profile.getAvatarUrlPath())) {
             logger.trace("Downloading profile avatar for {}", recipientId);
@@ -341,7 +348,7 @@ public final class ProfileHelper {
             Profile newProfile = null;
             if (profileKey.isPresent()) {
                 logger.trace("Decrypting profile");
-                newProfile = decryptProfileAndDownloadAvatar(recipientId, profileKey.get(), encryptedProfile);
+                newProfile = decryptProfileAndDownloadAvatar(recipientId, profileKey.get(), encryptedProfile, false);
             }
 
             if (newProfile == null) {

--- a/lib/src/main/java/org/asamk/signal/manager/helper/ReceiveHelper.java
+++ b/lib/src/main/java/org/asamk/signal/manager/helper/ReceiveHelper.java
@@ -40,7 +40,7 @@ public class ReceiveHelper {
     private final SignalDependencies dependencies;
     private final Context context;
 
-    private ReceiveConfig receiveConfig = new ReceiveConfig(false, false, false);
+    private ReceiveConfig receiveConfig = new ReceiveConfig(false, false, false, false, false);
     private boolean hasCaughtUpWithOldMessages = false;
     private boolean isWaitingForMessage = false;
     private boolean shouldStop = false;

--- a/lib/src/main/java/org/asamk/signal/manager/jobs/DownloadProfileAvatarJob.java
+++ b/lib/src/main/java/org/asamk/signal/manager/jobs/DownloadProfileAvatarJob.java
@@ -18,6 +18,6 @@ public class DownloadProfileAvatarJob implements Job {
         logger.trace("Downloading profile avatar {}", avatarPath);
         final var account = context.getAccount();
         context.getProfileHelper()
-                .downloadProfileAvatar(account.getSelfRecipientId(), avatarPath, account.getProfileKey());
+                .downloadProfileAvatar(account.getSelfRecipientId(), avatarPath, account.getProfileKey(), false);
     }
 }

--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -587,6 +587,12 @@ Don’t download attachments of received messages.
 *--ignore-stories*::
 Don’t receive story messages from the server.
 
+*--ignore-avatars*::
+Don't download avatars of received messages.
+
+*--ignore-stickers*::
+Don't download sticker packs of received messages.
+
 
 *--send-read-receipts*::
 Send read receipts for all incoming data messages (in addition to the default delivery receipts)
@@ -950,6 +956,12 @@ Don’t download attachments of received messages.
 *--ignore-stories*::
 Don’t receive story messages from the server.
 
+*--ignore-avatars*::
+Don't download avatars of received messages.
+
+*--ignore-stickers*::
+Don't download sticker packs of received messages.
+
 *--send-read-receipts*::
 Send read receipts for all incoming data messages (in addition to the default delivery receipts)
 
@@ -970,6 +982,12 @@ Don’t download attachments of received messages.
 
 *--ignore-stories*::
 Don’t receive story messages from the server.
+
+*--ignore-avatars*::
+Don't download avatars of received messages.
+
+*--ignore-stickers*::
+Don't download sticker packs of received messages.
 
 *--send-read-receipts*::
 Send read receipts for all incoming data messages (in addition to the default delivery receipts)

--- a/src/main/java/org/asamk/signal/commands/DaemonCommand.java
+++ b/src/main/java/org/asamk/signal/commands/DaemonCommand.java
@@ -82,6 +82,12 @@ public class DaemonCommand implements MultiLocalCommand, LocalCommand {
         subparser.addArgument("--ignore-stories")
                 .help("Don’t receive story messages from the server.")
                 .action(Arguments.storeTrue());
+        subparser.addArgument("--ignore-avatars")
+                .help("Don't download avatars of received messages.")
+                .action(Arguments.storeTrue());
+        subparser.addArgument("--ignore-stickers")
+                .help("Don't download sticker packs of received messages.")
+                .action(Arguments.storeTrue());
         subparser.addArgument("--send-read-receipts")
                 .help("Send read receipts for all incoming data messages (in addition to the default delivery receipts)")
                 .action(Arguments.storeTrue());

--- a/src/main/java/org/asamk/signal/commands/JsonRpcDispatcherCommand.java
+++ b/src/main/java/org/asamk/signal/commands/JsonRpcDispatcherCommand.java
@@ -44,6 +44,12 @@ public class JsonRpcDispatcherCommand implements LocalCommand, MultiLocalCommand
         subparser.addArgument("--ignore-stories")
                 .help("Don’t receive story messages from the server.")
                 .action(Arguments.storeTrue());
+        subparser.addArgument("--ignore-avatars")
+                .help("Don't download avatars of received messages.")
+                .action(Arguments.storeTrue());
+        subparser.addArgument("--ignore-stickers")
+                .help("Don't download sticker packs of received messages.")
+                .action(Arguments.storeTrue());
         subparser.addArgument("--send-read-receipts")
                 .help("Send read receipts for all incoming data messages (in addition to the default delivery receipts)")
                 .action(Arguments.storeTrue());

--- a/src/main/java/org/asamk/signal/commands/ReceiveCommand.java
+++ b/src/main/java/org/asamk/signal/commands/ReceiveCommand.java
@@ -55,6 +55,12 @@ public class ReceiveCommand implements LocalCommand, JsonRpcSingleCommand<Receiv
         subparser.addArgument("--ignore-stories")
                 .help("Don’t receive story messages from the server.")
                 .action(Arguments.storeTrue());
+        subparser.addArgument("--ignore-avatars")
+                .help("Don't download avatars of received messages.")
+                .action(Arguments.storeTrue());
+        subparser.addArgument("--ignore-stickers")
+                .help("Don't download sticker packs of received messages.")
+                .action(Arguments.storeTrue());
         subparser.addArgument("--send-read-receipts")
                 .help("Send read receipts for all incoming data messages (in addition to the default delivery receipts)")
                 .action(Arguments.storeTrue());
@@ -76,8 +82,10 @@ public class ReceiveCommand implements LocalCommand, JsonRpcSingleCommand<Receiv
         final var maxMessagesRaw = ns.getInt("max-messages");
         final var ignoreAttachments = Boolean.TRUE.equals(ns.getBoolean("ignore-attachments"));
         final var ignoreStories = Boolean.TRUE.equals(ns.getBoolean("ignore-stories"));
+        final var ignoreAvatars = Boolean.TRUE.equals(ns.getBoolean("ignore-avatars"));
+        final var ignoreStickers = Boolean.TRUE.equals(ns.getBoolean("ignore-stickers"));
         final var sendReadReceipts = Boolean.TRUE.equals(ns.getBoolean("send-read-receipts"));
-        m.setReceiveConfig(new ReceiveConfig(ignoreAttachments, ignoreStories, sendReadReceipts));
+        m.setReceiveConfig(new ReceiveConfig(ignoreAttachments, ignoreStories, ignoreAvatars, ignoreStickers, sendReadReceipts));
         try {
             final var handler = switch (outputWriter) {
                 case JsonWriter writer -> new JsonReceiveMessageHandler(m, writer);

--- a/src/main/java/org/asamk/signal/util/CommandUtil.java
+++ b/src/main/java/org/asamk/signal/util/CommandUtil.java
@@ -146,8 +146,10 @@ public class CommandUtil {
     public static ReceiveConfig getReceiveConfig(final Namespace ns) {
         final var ignoreAttachments = Boolean.TRUE.equals(ns.getBoolean("ignore-attachments"));
         final var ignoreStories = Boolean.TRUE.equals(ns.getBoolean("ignore-stories"));
+        final var ignoreAvatars = Boolean.TRUE.equals(ns.getBoolean("ignore-avatars"));
+        final var ignoreStickers = Boolean.TRUE.equals(ns.getBoolean("ignore-stickers"));
         final var sendReadReceipts = Boolean.TRUE.equals(ns.getBoolean("send-read-receipts"));
 
-        return new ReceiveConfig(ignoreAttachments, ignoreStories, sendReadReceipts);
+        return new ReceiveConfig(ignoreAttachments, ignoreStories, ignoreAvatars, ignoreStickers, sendReadReceipts);
     }
 }


### PR DESCRIPTION
Implement two new CLI flags to disable downloading avatars and sticker packs during message reception, following the existing pattern of --ignore-attachments and --ignore-stories flags.

Changes:
- Add --ignore-avatars and --ignore-stickers flags to ReceiveCommand, DaemonCommand, and JsonRpcDispatcherCommand
- Extend ReceiveConfig record with ignoreAvatars and ignoreStickers fields
- Add ReceiveHelper.getReceiveConfig() getter to expose config to other helpers
- Gate avatar downloads in ProfileHelper (profile avatars), SyncHelper (contact avatars), and GroupHelper (group avatars for V1 and V2)
- Gate sticker pack downloads in IncomingMessageHandler for both direct sticker messages and sync sticker pack operations
- Update handleSignalServiceDataMessage and handleSyncMessage to pass full ReceiveConfig instead of individual boolean flags
- Update man page (signal-cli.1.adoc) with flag documentation
- Add entries to CHANGELOG.md

When these flags are set, the respective content is not downloaded during message reception. Metadata (avatar paths, sticker pack IDs) is still stored, and existing FileNotFoundException handling will surface if content is later requested but wasn't downloaded.

Fixes #1903