### PR TITLE
Add --captcha flag example to registration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,10 @@ of all country codes.)
      ```
 
   Registering may require solving a CAPTCHA
-  challenge: [Registration with captcha](https://github.com/AsamK/signal-cli/wiki/Registration-with-captcha)
+  challenge: [Registration with captcha](https://github.com/AsamK/signal-cli/wiki/Registration-with-captcha).
+  In this case, provide the captcha token with the `--captcha` flag:
+
+      signal-cli -a ACCOUNT register --captcha CAPTCHA_TOKEN
 
 * Verify the number using the code received via SMS or voice, optionally add `--pin PIN_CODE` if you've added a pin code
   to your account


### PR DESCRIPTION
## Summary
- Added an inline command example showing the `--captcha` flag in the README registration section
- The existing docs mention captcha may be required and link to the wiki, but don't show the actual command syntax, which can cause users to miss this required step

## Test plan
- [ ] Verify the README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)