### PR TITLE
Fix: preserve quote context when author is null or invalid

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/api/MessageEnvelope.java
+++ b/lib/src/main/java/org/asamk/signal/manager/api/MessageEnvelope.java
@@ -145,7 +145,6 @@ public record MessageEnvelope(
                     dataMessage.getProfileKey().isPresent(),
                     dataMessage.getReaction().map(r -> Reaction.from(r, recipientResolver, addressResolver)),
                     dataMessage.getQuote()
-                            .filter(q -> q.getAuthor() != null && q.getAuthor().isValid())
                             .map(q -> Quote.from(q, recipientResolver, addressResolver, fileProvider)),
                     dataMessage.getPayment().map(p -> p.getPaymentNotification().isPresent() ? Payment.from(p) : null),
                     dataMessage.getAttachments()
@@ -242,9 +241,11 @@ public record MessageEnvelope(
                     final AttachmentFileProvider fileProvider
             ) {
                 return new Quote(quote.getId(),
-                        addressResolver.resolveRecipientAddress(recipientResolver.resolveRecipient(quote.getAuthor()))
-                                .toApiRecipientAddress(),
-                        Optional.of(quote.getText()),
+                        quote.getAuthor() != null && quote.getAuthor().isValid()
+                                ? addressResolver.resolveRecipientAddress(recipientResolver.resolveRecipient(quote.getAuthor()))
+                                        .toApiRecipientAddress()
+                                : new RecipientAddress(RecipientAddress.UNKNOWN_UUID),
+                        Optional.ofNullable(quote.getText()),
                         quote.getMentions() == null
                                 ? List.of()
                                 : quote.getMentions()


### PR DESCRIPTION
Fixes #1935

## Problem
When receiving a quoted/replied message, signal-cli silently drops the quote data if the quote author's ServiceId is null or fails the `isValid()` check. This means consumers of the signal-cli API (JSON-RPC, D-Bus) never receive quote context for these messages.

The root cause is an overly strict `.filter()` on the quote Optional in `MessageEnvelope.java` that discards the entire quote when the author can't be resolved, rather than preserving the quote with a fallback author.

## Fix
1. Remove the `.filter(q -> q.getAuthor() != null && q.getAuthor().isValid())` that drops quotes entirely
2. In `Quote.from()`, handle null/invalid authors by falling back to `RecipientAddress.UNKNOWN_UUID`
3. Use `Optional.ofNullable()` for quote text (defensive)

## Testing
This fix has been tested in production with a source-built 0.14.0-SNAPSHOT:
- Message delivery works normally (two checkmarks)
- Quote/reply context now flows through to JSON-RPC consumers
- No regressions in message sending or receiving
