### PR TITLE
Enforce poll choices are between 2 and 10

### DIFF
--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -442,6 +442,7 @@ By default, recipients can select multiple options.
 
 *-o* OPTION [OPTION ...], *--option* OPTION [OPTION ...]*::
 The options for the poll.
+Between 2 and 10 options must be specified.
 
 === sendPollVote
 

--- a/src/main/java/org/asamk/signal/commands/SendPollCreateCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendPollCreateCommand.java
@@ -24,6 +24,7 @@ import static org.asamk.signal.util.SendMessageResultUtils.outputResult;
 public class SendPollCreateCommand implements JsonRpcLocalCommand {
 
     private static final Logger logger = LoggerFactory.getLogger(SendPollCreateCommand.class);
+    private static final int MAX_POLL_OPTIONS = 10;
 
     @Override
     public String getName() {
@@ -71,6 +72,9 @@ public class SendPollCreateCommand implements JsonRpcLocalCommand {
         final var options = ns.<String>getList("option");
         if (options.size() < 2) {
             throw new UserErrorException("Poll needs at least two options");
+        }
+        if (options.size() > MAX_POLL_OPTIONS) {
+            throw new UserErrorException("Poll cannot have more than " + MAX_POLL_OPTIONS + " options");
         }
 
         try {


### PR DESCRIPTION
I noticed it was failing silently when I was trying to create a poll with more than 10 options. This PR just updates the documentation and code to reflect this hard limit of 10 poll options.