### PR TITLE
Enforce poll option length between 1 and 100

### DIFF
--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -443,6 +443,7 @@ By default, recipients can select multiple options.
 *-o* OPTION [OPTION ...], *--option* OPTION [OPTION ...]*::
 The options for the poll.
 Between 2 and 10 options must be specified.
+Each option must be between 1 and 100 characters.
 
 === sendPollVote
 

--- a/src/main/java/org/asamk/signal/commands/SendPollCreateCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendPollCreateCommand.java
@@ -25,6 +25,7 @@ public class SendPollCreateCommand implements JsonRpcLocalCommand {
 
     private static final Logger logger = LoggerFactory.getLogger(SendPollCreateCommand.class);
     private static final int MAX_POLL_OPTIONS = 10;
+    private static final int MAX_POLL_OPTION_LENGTH = 100;
 
     @Override
     public String getName() {
@@ -75,6 +76,14 @@ public class SendPollCreateCommand implements JsonRpcLocalCommand {
         }
         if (options.size() > MAX_POLL_OPTIONS) {
             throw new UserErrorException("Poll cannot have more than " + MAX_POLL_OPTIONS + " options");
+        }
+        for (final var option : options) {
+            if (option.isEmpty()) {
+                throw new UserErrorException("Poll options must not be empty");
+            }
+            if (option.length() > MAX_POLL_OPTION_LENGTH) {
+                throw new UserErrorException("Poll option \"" + option + "\" exceeds the maximum length of " + MAX_POLL_OPTION_LENGTH + " characters");
+            }
         }
 
         try {


### PR DESCRIPTION
One more poll issue I ran into: poll creation will also fail silently if you have a poll option greater than 100 characters (Signal UI enforces this max char limit). Same thing if you have an poll option of length < 1 (empty).