### PR TITLE
Add --voice-note flag for send command

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/api/Message.java
+++ b/lib/src/main/java/org/asamk/signal/manager/api/Message.java
@@ -7,6 +7,7 @@ public record Message(
         String messageText,
         List<String> attachments,
         boolean viewOnce,
+        boolean voiceNote,
         List<Mention> mentions,
         Optional<Quote> quote,
         Optional<Sticker> sticker,

--- a/lib/src/main/java/org/asamk/signal/manager/helper/AttachmentHelper.java
+++ b/lib/src/main/java/org/asamk/signal/manager/helper/AttachmentHelper.java
@@ -44,8 +44,8 @@ public class AttachmentHelper {
         return attachmentStore.retrieveAttachment(id);
     }
 
-    public List<SignalServiceAttachment> uploadAttachments(final List<String> attachments) throws AttachmentInvalidException, IOException {
-        final var attachmentStreams = createAttachmentStreams(attachments);
+    public List<SignalServiceAttachment> uploadAttachments(final List<String> attachments, boolean voiceNote) throws AttachmentInvalidException, IOException {
+        final var attachmentStreams = createAttachmentStreams(attachments, voiceNote);
 
         try {
             // Upload attachments here, so we only upload once even for multiple recipients
@@ -61,14 +61,18 @@ public class AttachmentHelper {
         }
     }
 
-    private List<SignalServiceAttachmentStream> createAttachmentStreams(List<String> attachments) throws AttachmentInvalidException, IOException {
+    public List<SignalServiceAttachment> uploadAttachments(final List<String> attachments) throws AttachmentInvalidException, IOException {
+        return uploadAttachments(attachments, false);
+    }
+
+    private List<SignalServiceAttachmentStream> createAttachmentStreams(List<String> attachments, boolean voiceNote) throws AttachmentInvalidException, IOException {
         if (attachments == null) {
             return null;
         }
         final var signalServiceAttachments = new ArrayList<SignalServiceAttachmentStream>(attachments.size());
         for (var attachment : attachments) {
             final var uploadSpec = dependencies.getMessageSender().getResumableUploadSpec();
-            signalServiceAttachments.add(AttachmentUtils.createAttachmentStream(attachment, uploadSpec));
+            signalServiceAttachments.add(AttachmentUtils.createAttachmentStream(attachment, voiceNote, uploadSpec));
         }
         return signalServiceAttachments;
     }

--- a/lib/src/main/java/org/asamk/signal/manager/internal/ManagerImpl.java
+++ b/lib/src/main/java/org/asamk/signal/manager/internal/ManagerImpl.java
@@ -843,7 +843,7 @@ public class ManagerImpl implements Manager {
             messageBuilder.withBody(message.messageText());
         }
         if (!message.attachments().isEmpty()) {
-            final var uploadedAttachments = context.getAttachmentHelper().uploadAttachments(message.attachments());
+            final var uploadedAttachments = context.getAttachmentHelper().uploadAttachments(message.attachments(), message.voiceNote());
             if (!additionalAttachments.isEmpty()) {
                 additionalAttachments.addAll(uploadedAttachments);
                 messageBuilder.withAttachments(additionalAttachments);

--- a/lib/src/main/java/org/asamk/signal/manager/util/AttachmentUtils.java
+++ b/lib/src/main/java/org/asamk/signal/manager/util/AttachmentUtils.java
@@ -14,15 +14,42 @@ public class AttachmentUtils {
 
     public static SignalServiceAttachmentStream createAttachmentStream(
             String attachment,
+            boolean voiceNote,
             ResumableUploadSpec resumableUploadSpec
     ) throws AttachmentInvalidException {
         try {
             final var streamDetails = Utils.createStreamDetails(attachment);
 
-            return createAttachmentStream(streamDetails.first(), streamDetails.second(), resumableUploadSpec);
+            return createAttachmentStream(streamDetails.first(), streamDetails.second(), voiceNote, resumableUploadSpec);
         } catch (IOException e) {
             throw new AttachmentInvalidException(attachment, e);
         }
+    }
+
+    public static SignalServiceAttachmentStream createAttachmentStream(
+            String attachment,
+            ResumableUploadSpec resumableUploadSpec
+    ) throws AttachmentInvalidException {
+        return createAttachmentStream(attachment, false, resumableUploadSpec);
+    }
+
+    public static SignalServiceAttachmentStream createAttachmentStream(
+            StreamDetails streamDetails,
+            Optional<String> name,
+            boolean voiceNote,
+            ResumableUploadSpec resumableUploadSpec
+    ) throws ResumeLocationInvalidException {
+        final var uploadTimestamp = System.currentTimeMillis();
+        return SignalServiceAttachmentStream.newStreamBuilder()
+                .withStream(streamDetails.getStream())
+                .withContentType(streamDetails.getContentType())
+                .withLength(streamDetails.getLength())
+                .withFileName(name.orElse(null))
+                .withVoiceNote(voiceNote)
+                .withUploadTimestamp(uploadTimestamp)
+                .withResumableUploadSpec(resumableUploadSpec)
+                .withUuid(UUID.randomUUID())
+                .build();
     }
 
     public static SignalServiceAttachmentStream createAttachmentStream(
@@ -30,16 +57,6 @@ public class AttachmentUtils {
             Optional<String> name,
             ResumableUploadSpec resumableUploadSpec
     ) throws ResumeLocationInvalidException {
-        // TODO maybe add a parameter to set the voiceNote, borderless, preview, width, height and caption option
-        final var uploadTimestamp = System.currentTimeMillis();
-        return SignalServiceAttachmentStream.newStreamBuilder()
-                .withStream(streamDetails.getStream())
-                .withContentType(streamDetails.getContentType())
-                .withLength(streamDetails.getLength())
-                .withFileName(name.orElse(null))
-                .withUploadTimestamp(uploadTimestamp)
-                .withResumableUploadSpec(resumableUploadSpec)
-                .withUuid(UUID.randomUUID())
-                .build();
+        return createAttachmentStream(streamDetails, name, false, resumableUploadSpec);
     }
 }

--- a/src/main/java/org/asamk/signal/commands/SendCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendCommand.java
@@ -109,6 +109,9 @@ public class SendCommand implements JsonRpcLocalCommand {
                 .action(Arguments.storeTrue())
                 .help("Send the message without the urgent flag, so no push notification is triggered for the recipient. "
                         + "The message will still be delivered in real-time if the recipient's app is active.");
+        subparser.addArgument("--voice-note")
+                .action(Arguments.storeTrue())
+                .help("Mark audio attachments as voice notes. Voice notes are displayed inline in Signal clients.");
     }
 
     @Override
@@ -171,6 +174,7 @@ public class SendCommand implements JsonRpcLocalCommand {
             attachments = List.of();
         }
         final var viewOnce = Boolean.TRUE.equals(ns.getBoolean("view-once"));
+        final var voiceNote = Boolean.TRUE.equals(ns.getBoolean("voice-note"));
 
         final var selfNumber = m.getSelfNumber();
 
@@ -247,6 +251,7 @@ public class SendCommand implements JsonRpcLocalCommand {
             final var message = new Message(messageText,
                     attachments,
                     viewOnce,
+                    voiceNote,
                     mentions,
                     Optional.ofNullable(quote),
                     Optional.ofNullable(sticker),

--- a/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusSignalImpl.java
@@ -238,6 +238,7 @@ public class DbusSignalImpl implements Signal, AutoCloseable {
             final var message = new Message(messageText,
                     attachments,
                     false,
+                    false,
                     List.of(),
                     Optional.empty(),
                     Optional.empty(),
@@ -404,6 +405,7 @@ public class DbusSignalImpl implements Signal, AutoCloseable {
             final var message = new Message(messageText,
                     attachments,
                     false,
+                    false,
                     List.of(),
                     Optional.empty(),
                     Optional.empty(),
@@ -450,6 +452,7 @@ public class DbusSignalImpl implements Signal, AutoCloseable {
         try {
             final var message = new Message(messageText,
                     attachments,
+                    false,
                     false,
                     List.of(),
                     Optional.empty(),


### PR DESCRIPTION
## Summary

Add support for marking audio attachments as voice notes when sending messages via CLI and JSON-RPC.

Without this flag, audio attachments are sent as regular file attachments. Signal clients (especially iOS) do not provide an inline audio player for regular attachments — only voice notes get the play button UI.

## Changes

- Add `voiceNote` field to `Message` record
- Pass `voiceNote` flag through `AttachmentHelper` → `AttachmentUtils`
- Call `.withVoiceNote()` on `SignalServiceAttachmentStream` builder
- Add `--voice-note` CLI argument to `SendCommand`
- `voiceNote` parameter works automatically in JSON-RPC mode (camelCase mapping)
- DBus interface defaults to `false` (no breaking change)

## Usage

**CLI:**
```
signal-cli send -a voice.m4a --voice-note +1234567890
```

**JSON-RPC:**
```json
{"jsonrpc":"2.0","method":"send","params":{"recipient":["+1234567890"],"message":"","attachment":"voice.m4a","voiceNote":true},"id":1}
```

## Context

This addresses the TODO comment already present in `AttachmentUtils.java`:
```java
// TODO maybe add a parameter to set the voiceNote, borderless, preview, width, height and caption option
```

Closes #1601 (partially — this PR covers `voiceNote`; the other attachment metadata fields like `caption`, `borderless`, `width`, `height` could follow in a similar pattern).