### PR TITLE
Fix NullPointerException in AttachmentStore.retrieveAttachment upon receipt of voice messages

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/storage/AttachmentStore.java
+++ b/lib/src/main/java/org/asamk/signal/manager/storage/AttachmentStore.java
@@ -44,6 +44,9 @@ public class AttachmentStore {
     }
 
     public StreamDetails retrieveAttachment(final String id) throws IOException {
+        if (id == null || id.isEmpty()) {
+            throw new IOException("Attachment ID must not be null or empty");
+        }
         final var attachmentFile = new File(attachmentsPath, id);
         return Utils.createStreamDetailsFromFile(attachmentFile);
     }


### PR DESCRIPTION
## Problem
The following happened when I sent a voice message from my Android phone to signal-cli via hermes-agent on my Mac.

`AttachmentStore.retrieveAttachment()` throws a `NullPointerException` when called via JSON-RPC with a null attachment ID. This happens when a JSON-RPC client passes the attachment ID under a parameter name that doesn't match the expected `id` key (e.g. `attachmentId`). The `JsonRpcNamespace` lookup returns `null`, which propagates through to `new File(attachmentsPath, null)`.

Stack trace:
```
java.lang.NullPointerException
    at java.base/java.io.File.<init>(File.java:366)
    at org.asamk.signal.manager.storage.AttachmentStore.retrieveAttachment(AttachmentStore.java:47)
    at org.asamk.signal.manager.helper.AttachmentHelper.retrieveAttachment(AttachmentHelper.java:44)
    at org.asamk.signal.manager.internal.ManagerImpl.retrieveAttachment(ManagerImpl.java:1709)
    at org.asamk.signal.commands.GetAttachmentCommand.handleCommand(GetAttachmentCommand.java:45)
```

## Fix

Add a null/empty guard in `retrieveAttachment()` that throws a descriptive `IOException` instead of an opaque NPE. This makes the error actionable for JSON-RPC clients that send an incorrect parameter name.
