### PR TITLE
Fix SQLiteException in RecipientStore.resolveRecipient on cache hit

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/storage/recipients/RecipientStore.java
+++ b/lib/src/main/java/org/asamk/signal/manager/storage/recipients/RecipientStore.java
@@ -184,12 +184,12 @@ public class RecipientStore implements RecipientIdCreator, RecipientResolver, Re
 
     @Override
     public RecipientId resolveRecipient(final ServiceId serviceId) {
+        final var recipientWithAddress = recipientAddressCache.get(serviceId);
+        if (recipientWithAddress != null) {
+            return recipientWithAddress.id();
+        }
         try (final var connection = database.getConnection()) {
             connection.setAutoCommit(false);
-            final var recipientWithAddress = recipientAddressCache.get(serviceId);
-            if (recipientWithAddress != null) {
-                return recipientWithAddress.id();
-            }
             final var recipientId = resolveRecipientLocked(connection, serviceId);
             connection.commit();
             return recipientId;


### PR DESCRIPTION
## Problem

When running signal-cli in daemon mode under load (e.g. rapid group creation during batch operations), the following exception occurs intermittently:

```
org.sqlite.SQLiteException: [SQLITE_ERROR] SQL error or missing database (cannot commit - no transaction is active)
    at org.asamk.signal.manager.storage.recipients.RecipientStore.resolveRecipient(RecipientStore.java:197)
```

This causes signal-cli to stop processing messages until restarted.

## Root Cause

`resolveRecipient(ServiceId)` opens a pooled HikariCP connection and calls `setAutoCommit(false)`, which executes `BEGIN IMMEDIATE` via the configured `TransactionMode.IMMEDIATE`. It then checks the in-memory `recipientAddressCache`. On a cache hit, the method returns early via try-with-resources, closing the connection **without calling `commit()` or `rollback()`**.

When HikariCP reclaims the connection, it calls `setAutoCommit(true)` to reset it for the next borrower. The xerial sqlite-jdbc driver's `setAutoCommit(true)` [unconditionally executes `COMMIT`](https://github.com/xerial/sqlite-jdbc/blob/master/src/main/java/org/sqlite/jdbc3/JDBC3Connection.java#L365). However, SQLite already implicitly rolled back the transaction when the connection was returned to the pool — so the `COMMIT` fails with "cannot commit - no transaction is active".

This corrupts the pooled connection's internal state. Subsequent operations using this connection may fail or behave unpredictably.

## Fix

Move the cache check **before** `getConnection()`. On cache hits, no connection is opened and no transaction is started. On cache misses, the existing behavior is preserved: open a connection, `BEGIN IMMEDIATE`, resolve or create the recipient, `COMMIT`.

This is a single-line logical reordering with no behavioral change for the cache-miss path.

## Related Issues

- #1670 — SQLite database is locked error (discusses HikariCP pool size and SQLite contention)
- #1675 — Occasional deadlocks on DB (related connection pool issues, led to PR #1674)

## Reproduction

This occurs most reliably when signal-cli daemon processes many concurrent or rapid-sequential operations that resolve recipients — for example, creating multiple groups in quick succession. Each `create_group` call triggers `resolveRecipient` for each member, and with high cache hit rates, the early-return path is exercised frequently.

## Alternatives Considered

- **Explicitly calling `rollback()` before the early return**: Would fix the immediate issue but still unnecessarily acquires a connection and starts a transaction for a cache lookup. Moving the cache check avoids the connection entirely.
- **Reducing `maximumPoolSize`**: Reduces the probability of hitting the bug by limiting pooled connection reuse, but doesn't fix the root cause. The pool size is also a separate discussion (see #1670).
- **Switching read-only methods to `DEFERRED` transactions**: `resolveRecipient` is a "resolve or create" operation — it may write on cache miss, so `IMMEDIATE` is correct for the cache-miss path. The fix avoids the transaction entirely on cache hits.