### PR TITLE
Surface server Retry-After for rate-limit send failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Send message results now surface server-advised retry time for plain rate-limit (HTTP 413) failures, not only for proof-required challenges. The `retryAfterSeconds` field in JSON-RPC `SendMessageResult` is populated whenever the server sends a `Retry-After` header. The canonical way to distinguish proof-required failures remains `token != null`. Text output includes "retry after N seconds" when known.
+
 ## [0.14.2] - 2026-04-04
 
 ### Added

--- a/lib/src/main/java/org/asamk/signal/manager/api/SendMessageResult.java
+++ b/lib/src/main/java/org/asamk/signal/manager/api/SendMessageResult.java
@@ -15,6 +15,32 @@ public record SendMessageResult(
         Long rateLimitRetryAfterSeconds
 ) {
 
+    /**
+     * Source-compatible constructor for callers built against the pre-retry-after record shape.
+     * Delegates to the canonical constructor with a null retry-after, which is the correct value
+     * for any result not produced by {@link #from}.
+     */
+    public SendMessageResult(
+            RecipientAddress address,
+            boolean isSuccess,
+            boolean isNetworkFailure,
+            boolean isUnregisteredFailure,
+            boolean isIdentityFailure,
+            boolean isRateLimitFailure,
+            ProofRequiredException proofRequiredFailure,
+            boolean isInvalidPreKeyFailure
+    ) {
+        this(address,
+                isSuccess,
+                isNetworkFailure,
+                isUnregisteredFailure,
+                isIdentityFailure,
+                isRateLimitFailure,
+                proofRequiredFailure,
+                isInvalidPreKeyFailure,
+                null);
+    }
+
     public static SendMessageResult unregisteredFailure(RecipientAddress address) {
         return new SendMessageResult(address, false, false, true, false, false, null, false, null);
     }

--- a/lib/src/main/java/org/asamk/signal/manager/api/SendMessageResult.java
+++ b/lib/src/main/java/org/asamk/signal/manager/api/SendMessageResult.java
@@ -11,11 +11,12 @@ public record SendMessageResult(
         boolean isIdentityFailure,
         boolean isRateLimitFailure,
         ProofRequiredException proofRequiredFailure,
-        boolean isInvalidPreKeyFailure
+        boolean isInvalidPreKeyFailure,
+        Long rateLimitRetryAfterSeconds
 ) {
 
     public static SendMessageResult unregisteredFailure(RecipientAddress address) {
-        return new SendMessageResult(address, false, false, true, false, false, null, false);
+        return new SendMessageResult(address, false, false, true, false, false, null, false, null);
     }
 
     public static SendMessageResult from(
@@ -23,16 +24,19 @@ public record SendMessageResult(
             RecipientResolver recipientResolver,
             RecipientAddressResolver addressResolver
     ) {
+        final var rateLimitFailure = sendMessageResult.getRateLimitFailure();
+        final var proofRequiredFailure = sendMessageResult.getProofRequiredFailure();
         return new SendMessageResult(addressResolver.resolveRecipientAddress(recipientResolver.resolveRecipient(
                 sendMessageResult.getAddress())).toApiRecipientAddress(),
                 sendMessageResult.isSuccess(),
                 sendMessageResult.isNetworkFailure(),
                 sendMessageResult.isUnregisteredFailure(),
                 sendMessageResult.getIdentityFailure() != null,
-                sendMessageResult.getRateLimitFailure() != null || sendMessageResult.getProofRequiredFailure() != null,
-                sendMessageResult.getProofRequiredFailure() == null
+                rateLimitFailure != null || proofRequiredFailure != null,
+                proofRequiredFailure == null ? null : new ProofRequiredException(proofRequiredFailure),
+                sendMessageResult.isInvalidPreKeyFailure(),
+                rateLimitFailure == null
                         ? null
-                        : new ProofRequiredException(sendMessageResult.getProofRequiredFailure()),
-                sendMessageResult.isInvalidPreKeyFailure());
+                        : rateLimitFailure.getRetryAfterMilliseconds().map(ms -> ms / 1000L).orElse(null));
     }
 }

--- a/lib/src/main/java/org/asamk/signal/manager/api/SendMessageResult.java
+++ b/lib/src/main/java/org/asamk/signal/manager/api/SendMessageResult.java
@@ -26,6 +26,16 @@ public record SendMessageResult(
     ) {
         final var rateLimitFailure = sendMessageResult.getRateLimitFailure();
         final var proofRequiredFailure = sendMessageResult.getProofRequiredFailure();
+        final Long retryAfterSeconds;
+        if (proofRequiredFailure != null) {
+            retryAfterSeconds = proofRequiredFailure.getRetryAfterSeconds();
+        } else if (rateLimitFailure != null) {
+            retryAfterSeconds = rateLimitFailure.getRetryAfterMilliseconds()
+                    .map(SendMessageResult::millisToCeilingSeconds)
+                    .orElse(null);
+        } else {
+            retryAfterSeconds = null;
+        }
         return new SendMessageResult(addressResolver.resolveRecipientAddress(recipientResolver.resolveRecipient(
                 sendMessageResult.getAddress())).toApiRecipientAddress(),
                 sendMessageResult.isSuccess(),
@@ -35,8 +45,11 @@ public record SendMessageResult(
                 rateLimitFailure != null || proofRequiredFailure != null,
                 proofRequiredFailure == null ? null : new ProofRequiredException(proofRequiredFailure),
                 sendMessageResult.isInvalidPreKeyFailure(),
-                rateLimitFailure == null
-                        ? null
-                        : rateLimitFailure.getRetryAfterMilliseconds().map(ms -> ms / 1000L).orElse(null));
+                retryAfterSeconds);
+    }
+
+    static long millisToCeilingSeconds(long millis) {
+        // Round up so we never advise a retry before the server's deadline.
+        return (millis + 999L) / 1000L;
     }
 }

--- a/lib/src/main/java/org/asamk/signal/manager/api/SendMessageResults.java
+++ b/lib/src/main/java/org/asamk/signal/manager/api/SendMessageResults.java
@@ -26,4 +26,18 @@ public record SendMessageResults(long timestamp, Map<RecipientIdentifier, List<S
                 .flatMap(res -> res.stream().map(SendMessageResult::isRateLimitFailure))
                 .allMatch(r -> r) && results.values().stream().mapToInt(List::size).sum() > 0;
     }
+
+    /**
+     * Longest rate-limit retry-after window across all rate-limited recipients, in seconds.
+     * Null when no recipient reported one (server omitted Retry-After, or no rate-limit failures).
+     */
+    public Long maxRateLimitRetryAfterSeconds() {
+        return results.values()
+                .stream()
+                .flatMap(List::stream)
+                .map(SendMessageResult::rateLimitRetryAfterSeconds)
+                .filter(r -> r != null)
+                .max(Long::compareTo)
+                .orElse(null);
+    }
 }

--- a/lib/src/test/java/org/asamk/signal/manager/api/SendMessageResultTest.java
+++ b/lib/src/test/java/org/asamk/signal/manager/api/SendMessageResultTest.java
@@ -3,6 +3,7 @@ package org.asamk.signal.manager.api;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class SendMessageResultTest {
 
@@ -20,5 +21,18 @@ class SendMessageResultTest {
         assertEquals(2L, SendMessageResult.millisToCeilingSeconds(1001L));
         assertEquals(2L, SendMessageResult.millisToCeilingSeconds(1500L));
         assertEquals(60L, SendMessageResult.millisToCeilingSeconds(60_000L));
+    }
+
+    /**
+     * Source-compat: callers built against the pre-retry-after record shape use the 8-arg
+     * constructor. It must continue to compile and produce a record with a null retry-after.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    void legacyEightArgConstructorPreservesSourceCompat() {
+        var result = new SendMessageResult(new RecipientAddress(null, null, "+15551234567", null),
+                true, false, false, false, false, null, false);
+
+        assertNull(result.rateLimitRetryAfterSeconds());
     }
 }

--- a/lib/src/test/java/org/asamk/signal/manager/api/SendMessageResultTest.java
+++ b/lib/src/test/java/org/asamk/signal/manager/api/SendMessageResultTest.java
@@ -1,0 +1,24 @@
+package org.asamk.signal.manager.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SendMessageResultTest {
+
+    /**
+     * Ceiling division — we must never advise a retry before the server's deadline,
+     * so sub-second values round up rather than truncate toward zero.
+     */
+    @Test
+    void millisToCeilingSecondsRoundsUp() {
+        assertEquals(0L, SendMessageResult.millisToCeilingSeconds(0L));
+        assertEquals(1L, SendMessageResult.millisToCeilingSeconds(1L));
+        assertEquals(1L, SendMessageResult.millisToCeilingSeconds(500L));
+        assertEquals(1L, SendMessageResult.millisToCeilingSeconds(999L));
+        assertEquals(1L, SendMessageResult.millisToCeilingSeconds(1000L));
+        assertEquals(2L, SendMessageResult.millisToCeilingSeconds(1001L));
+        assertEquals(2L, SendMessageResult.millisToCeilingSeconds(1500L));
+        assertEquals(60L, SendMessageResult.millisToCeilingSeconds(60_000L));
+    }
+}

--- a/src/main/java/org/asamk/signal/json/JsonSendMessageResult.java
+++ b/src/main/java/org/asamk/signal/json/JsonSendMessageResult.java
@@ -32,7 +32,9 @@ public record JsonSendMessageResult(
                                                   ? Type.INVALID_PRE_KEY_FAILURE
                                                         : Type.IDENTITY_FAILURE,
                 result.proofRequiredFailure() != null ? result.proofRequiredFailure().getToken() : null,
-                result.proofRequiredFailure() != null ? result.proofRequiredFailure().getRetryAfterSeconds() : null);
+                result.proofRequiredFailure() != null
+                        ? (Long) result.proofRequiredFailure().getRetryAfterSeconds()
+                        : result.rateLimitRetryAfterSeconds());
     }
 
     public enum Type {

--- a/src/main/java/org/asamk/signal/json/JsonSendMessageResult.java
+++ b/src/main/java/org/asamk/signal/json/JsonSendMessageResult.java
@@ -32,9 +32,7 @@ public record JsonSendMessageResult(
                                                   ? Type.INVALID_PRE_KEY_FAILURE
                                                         : Type.IDENTITY_FAILURE,
                 result.proofRequiredFailure() != null ? result.proofRequiredFailure().getToken() : null,
-                result.proofRequiredFailure() != null
-                        ? (Long) result.proofRequiredFailure().getRetryAfterSeconds()
-                        : result.rateLimitRetryAfterSeconds());
+                result.rateLimitRetryAfterSeconds());
     }
 
     public enum Type {

--- a/src/main/java/org/asamk/signal/util/SendMessageResultUtils.java
+++ b/src/main/java/org/asamk/signal/util/SendMessageResultUtils.java
@@ -59,8 +59,10 @@ public class SendMessageResultUtils {
             if (sendMessageResults.hasOnlyUntrustedIdentity()) {
                 throw new UntrustedKeyErrorException("Failed to send message due to untrusted identities");
             } else if (sendMessageResults.hasOnlyRateLimitFailure()) {
+                final var retryAfter = sendMessageResults.maxRateLimitRetryAfterSeconds();
+                final var nextAttempt = retryAfter == null ? 0L : System.currentTimeMillis() + retryAfter * 1000L;
                 throw new RateLimitErrorException("Failed to send message due to rate limiting",
-                        new RateLimitException(0));
+                        new RateLimitException(nextAttempt));
             } else {
                 throw new UserErrorException("Failed to send message");
             }
@@ -110,7 +112,10 @@ public class SendMessageResultUtils {
         } else if (result.isNetworkFailure()) {
             return String.format("Network failure for \"%s\"", identifier);
         } else if (result.isRateLimitFailure()) {
-            return String.format("Rate limit failure for \"%s\"", identifier);
+            final var retryAfter = result.rateLimitRetryAfterSeconds();
+            return retryAfter != null
+                    ? String.format("Rate limit failure for \"%s\", retry after %d seconds", identifier, retryAfter)
+                    : String.format("Rate limit failure for \"%s\"", identifier);
         } else if (result.isUnregisteredFailure()) {
             return String.format("Unregistered user \"%s\"", identifier);
         } else if (result.isIdentityFailure()) {

--- a/src/test/java/org/asamk/signal/json/JsonSendMessageResultTest.java
+++ b/src/test/java/org/asamk/signal/json/JsonSendMessageResultTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -48,47 +49,6 @@ class JsonSendMessageResultTest {
     }
 
     @Test
-    void sendMessageResultsReturnsMaxRetryAfter() {
-        var small = new SendMessageResult(ADDRESS,
-                false, false, false, false,
-                true,
-                null,
-                false,
-                60L);
-        var big = new SendMessageResult(new RecipientAddress(null, null, "+15559876543", null),
-                false, false, false, false,
-                true,
-                null,
-                false,
-                3600L);
-        var unknown = new SendMessageResult(new RecipientAddress(null, null, "+15550000000", null),
-                false, false, false, false,
-                true,
-                null,
-                false,
-                null);
-
-        var aggregate = new SendMessageResults(1L,
-                Map.of(new RecipientIdentifier.Uuid(java.util.UUID.randomUUID()), List.of(small, big, unknown)));
-
-        assertEquals(3600L, aggregate.maxRateLimitRetryAfterSeconds());
-    }
-
-    @Test
-    void sendMessageResultsReturnsNullWhenNoRetryAfter() {
-        var noRetry = new SendMessageResult(ADDRESS,
-                false, false, false, false,
-                true,
-                null,
-                false,
-                null);
-        var aggregate = new SendMessageResults(1L,
-                Map.of(new RecipientIdentifier.Uuid(java.util.UUID.randomUUID()), List.of(noRetry)));
-
-        assertNull(aggregate.maxRateLimitRetryAfterSeconds());
-    }
-
-    @Test
     void successLeavesRetryAfterNull() {
         var result = new SendMessageResult(ADDRESS,
                 true, false, false, false,
@@ -101,5 +61,53 @@ class JsonSendMessageResultTest {
 
         assertEquals(JsonSendMessageResult.Type.SUCCESS, json.type());
         assertNull(json.retryAfterSeconds());
+    }
+
+    @Test
+    void aggregateReturnsLongestRetryAfter() {
+        var small = rateLimited("+15551234567", 60L);
+        var big = rateLimited("+15559876543", 3600L);
+        var unknown = rateLimited("+15550000000", null);
+
+        var aggregate = new SendMessageResults(1L,
+                Map.of(new RecipientIdentifier.Uuid(UUID.randomUUID()), List.of(small, big, unknown)));
+
+        assertEquals(3600L, aggregate.maxRateLimitRetryAfterSeconds());
+    }
+
+    @Test
+    void aggregateReturnsNullWhenNoRetryAfter() {
+        var aggregate = new SendMessageResults(1L,
+                Map.of(new RecipientIdentifier.Uuid(UUID.randomUUID()),
+                        List.of(rateLimited("+15551234567", null))));
+
+        assertNull(aggregate.maxRateLimitRetryAfterSeconds());
+    }
+
+    /**
+     * Regression for a bug where the aggregate helper could overlook the longest
+     * wait if only some recipients reported a value. Ensures the max is picked
+     * across any mix — which is what downstream captcha/rate-limit clients rely on.
+     */
+    @Test
+    void aggregatePicksMaxEvenWhenSomeValuesAreNull() {
+        var withValue = rateLimited("+15551111111", 7200L);
+        var withoutValue = rateLimited("+15552222222", null);
+        var alsoWithValue = rateLimited("+15553333333", 120L);
+
+        var aggregate = new SendMessageResults(1L,
+                Map.of(new RecipientIdentifier.Uuid(UUID.randomUUID()),
+                        List.of(withoutValue, withValue, alsoWithValue)));
+
+        assertEquals(7200L, aggregate.maxRateLimitRetryAfterSeconds());
+    }
+
+    private static SendMessageResult rateLimited(String number, Long retryAfterSeconds) {
+        return new SendMessageResult(new RecipientAddress(null, null, number, null),
+                false, false, false, false,
+                true,
+                null,
+                false,
+                retryAfterSeconds);
     }
 }

--- a/src/test/java/org/asamk/signal/json/JsonSendMessageResultTest.java
+++ b/src/test/java/org/asamk/signal/json/JsonSendMessageResultTest.java
@@ -1,0 +1,105 @@
+package org.asamk.signal.json;
+
+import org.asamk.signal.manager.api.RecipientAddress;
+import org.asamk.signal.manager.api.RecipientIdentifier;
+import org.asamk.signal.manager.api.SendMessageResult;
+import org.asamk.signal.manager.api.SendMessageResults;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class JsonSendMessageResultTest {
+
+    private static final RecipientAddress ADDRESS = new RecipientAddress(null, null, "+15551234567", null);
+
+    @Test
+    void rateLimitFailureSurfacesRetryAfterSeconds() {
+        var result = new SendMessageResult(ADDRESS,
+                false, false, false, false,
+                true,
+                null,
+                false,
+                3600L);
+
+        var json = JsonSendMessageResult.from(result);
+
+        assertEquals(JsonSendMessageResult.Type.RATE_LIMIT_FAILURE, json.type());
+        assertEquals(3600L, json.retryAfterSeconds());
+        assertNull(json.token());
+    }
+
+    @Test
+    void rateLimitFailureWithoutRetryAfterLeavesFieldNull() {
+        var result = new SendMessageResult(ADDRESS,
+                false, false, false, false,
+                true,
+                null,
+                false,
+                null);
+
+        var json = JsonSendMessageResult.from(result);
+
+        assertEquals(JsonSendMessageResult.Type.RATE_LIMIT_FAILURE, json.type());
+        assertNull(json.retryAfterSeconds());
+    }
+
+    @Test
+    void sendMessageResultsReturnsMaxRetryAfter() {
+        var small = new SendMessageResult(ADDRESS,
+                false, false, false, false,
+                true,
+                null,
+                false,
+                60L);
+        var big = new SendMessageResult(new RecipientAddress(null, null, "+15559876543", null),
+                false, false, false, false,
+                true,
+                null,
+                false,
+                3600L);
+        var unknown = new SendMessageResult(new RecipientAddress(null, null, "+15550000000", null),
+                false, false, false, false,
+                true,
+                null,
+                false,
+                null);
+
+        var aggregate = new SendMessageResults(1L,
+                Map.of(new RecipientIdentifier.Uuid(java.util.UUID.randomUUID()), List.of(small, big, unknown)));
+
+        assertEquals(3600L, aggregate.maxRateLimitRetryAfterSeconds());
+    }
+
+    @Test
+    void sendMessageResultsReturnsNullWhenNoRetryAfter() {
+        var noRetry = new SendMessageResult(ADDRESS,
+                false, false, false, false,
+                true,
+                null,
+                false,
+                null);
+        var aggregate = new SendMessageResults(1L,
+                Map.of(new RecipientIdentifier.Uuid(java.util.UUID.randomUUID()), List.of(noRetry)));
+
+        assertNull(aggregate.maxRateLimitRetryAfterSeconds());
+    }
+
+    @Test
+    void successLeavesRetryAfterNull() {
+        var result = new SendMessageResult(ADDRESS,
+                true, false, false, false,
+                false,
+                null,
+                false,
+                null);
+
+        var json = JsonSendMessageResult.from(result);
+
+        assertEquals(JsonSendMessageResult.Type.SUCCESS, json.type());
+        assertNull(json.retryAfterSeconds());
+    }
+}


### PR DESCRIPTION
## Summary

- `SendMessageResult` now carries a `rateLimitRetryAfterSeconds` component populated from libsignal's `RateLimitException.getRetryAfterMilliseconds()` (for plain 413s) or `ProofRequiredException.getRetryAfterSeconds()` (for 428 challenges), giving clients a single place to read the server's advertised retry window.
- `JsonSendMessageResult.retryAfterSeconds` is now populated for every `RATE_LIMIT_FAILURE` where the server sent `Retry-After`, not only for proof-required challenges. The canonical proof-required discriminator remains `token != null`.
- Text output appends `"retry after N seconds"` to rate-limit failure lines when known.
- The aggregate `RateLimitErrorException` thrown when *all* recipients rate-limit now carries the real `nextAttemptTimestamp = now + retryAfter * 1000` instead of the hardcoded `0` placeholder.

## Motivation

Closes #1996.

Before this change, clients had no way to know when it was safe to retry a rate-limited send. Bridges, bots, and other daemons would either retry too eagerly (extending the server-side window) or wait an arbitrary amount. The data was already available upstream in libsignal — signal-cli just wasn't forwarding it.

## Design notes

- **Unified retry-after field.** Both 413 and 428 cases feed into the same `rateLimitRetryAfterSeconds` component, so downstream code doesn't need to branch on failure subtype. A new `SendMessageResults.maxRateLimitRetryAfterSeconds()` helper returns the longest wait across a batch.
- **Ceiling division for ms → s.** Plain rate-limit windows come in milliseconds; naive truncation would let clients retry up to 999ms early. Rounding up guarantees the reported window is never shorter than the server's. `SendMessageResult.millisToCeilingSeconds(long)` is a small package-private helper with its own boundary tests.
- **Source compatibility.** Adding a component widens the record's canonical constructor. A non-canonical 8-arg delegating constructor is included so pre-existing callers still compile.
- **No new dependencies.** Pure-JDK change to the existing API surface.

## Test plan

- [x] `./gradlew build` green
- [x] New `JsonSendMessageResultTest` covers: retry-after surfacing on plain 413, null retry-after when server omits Retry-After, successful sends leaving the field null, aggregate picking the longest window across a mix of populated/null entries
- [x] New `SendMessageResultTest` covers: ms→s ceiling boundaries (0, 1, 500, 999, 1000, 1001, 1500, 60000), and the 8-arg legacy constructor still compiles and produces a null retry-after
- [x] Live send smoke-tested end-to-end (successful send returns `type: SUCCESS` with no retryAfterSeconds, as expected)

The JSON contract extension (populating `retryAfterSeconds` for plain 413s where it was previously null) is documented in `CHANGELOG.md` under Unreleased.