### PR TITLE
Fix sender key re-distribution on every group message

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/helper/SendHelper.java
+++ b/lib/src/main/java/org/asamk/signal/manager/helper/SendHelper.java
@@ -705,6 +705,17 @@ public class SendHelper {
                     successCount,
                     addresses.size());
 
+            final var successfulAddresses = results.stream()
+                    .filter(SendMessageResult::isSuccess)
+                    .flatMap(r -> r.getSuccess()
+                            .getDevices()
+                            .stream()
+                            .map(device -> new SignalProtocolAddress(r.getAddress().getIdentifier(), device)))
+                    .toList();
+            if (!successfulAddresses.isEmpty()) {
+                account.getSenderKeyStore().markSenderKeySharedWith(distributionId, successfulAddresses);
+            }
+
             return results;
         } catch (org.whispersystems.signalservice.api.crypto.UntrustedIdentityException e) {
             return null;

--- a/lib/src/main/java/org/asamk/signal/manager/storage/senderKeys/SenderKeySharedStore.java
+++ b/lib/src/main/java/org/asamk/signal/manager/storage/senderKeys/SenderKeySharedStore.java
@@ -204,7 +204,7 @@ public class SenderKeySharedStore {
         ).formatted(TABLE_SENDER_KEY_SHARED);
         try (final var statement = connection.prepareStatement(sql)) {
             for (final var entry : newEntries) {
-                statement.setString(1, entry.toString());
+                statement.setString(1, entry.address());
                 statement.setInt(2, entry.deviceId());
                 statement.setBytes(3, UuidUtil.toByteArray(distributionId.asUuid()));
                 statement.setLong(4, System.currentTimeMillis());


### PR DESCRIPTION
Fixes #2018

## Fix sender key re-distribution on every group message

### Problem

When sending group messages via any signal-cli interface (DBus daemon, JSON-RPC, CLI),
every `sendGroupMessage` call re-distributes the sender key to all group members — even
when they already have the current distribution. This causes a ~6 second delay per message
because each re-distribution opens a fresh unidentified (sealed sender) TLS connection.

Log output observed on every send, including immediate consecutive messages:

```
DEBUG Can use sender key for 2/2 recipients.
INFO  Need to send the distribution message to 2 addresses.   ← every time
INFO  [LibSignalChatConnection]: [unidentified:...] Connecting...
# ~6 seconds later
INFO  Successfully sent sender keys to 2/2 recipients.
DEBUG Sending took PT6.581S
```

### Root cause

`SenderKeySharedStore.markSenderKeysSharedWith()` stores addresses using
`entry.toString()` instead of `entry.address()`.

Since `SenderKeySharedEntry` is a Java record, `toString()` returns the full record
representation rather than just the UUID:

```
# Stored in DB (wrong):
SenderKeySharedEntry[address=e32b08b1-0b1a-4869-a264-a0b7b8bb68ad, deviceId=1]

# Expected:
e32b08b1-0b1a-4869-a264-a0b7b8bb68ad
```

When signal-service-java subsequently calls `getSenderKeySharedWith()` and compares the
retrieved addresses against the actual group member UUIDs, the comparison always fails.
signal-service-java therefore believes the distribution has never been sent and re-sends
it on every `sendGroupMessage` call.

This can be confirmed by inspecting the SQLite `sender_key_shared` table — the `address`
column contains the full record `toString()` representation:

```sql
SELECT address FROM sender_key_shared LIMIT 1;
-- SenderKeySharedEntry[address=e32b08b1-0b1a-4869-a264-a0b7b8bb68ad, deviceId=1]
```

### Fix

One-character change in `SenderKeySharedStore.markSenderKeysSharedWith()`:

```java
// Before (wrong — stores full record toString())
statement.setString(1, entry.toString());

// After (correct — stores just the UUID address)
statement.setString(1, entry.address());
```

### Affected send modes

All send modes route through the same `SenderKeySharedStore` and are equally affected:

```
CLI send command
JSON-RPC (--socket / --http)
DBus daemon
       ↓
SignalServiceMessageSender.sendGroupDataMessage()
       ↓
SenderKeySharedStore.markSenderKeysSharedWith()  ← fix applied here
```

### Verified

After applying the fix, consecutive group messages no longer trigger
"Need to send the distribution message":

```
# Message 1 (first send after restart — distribution needed once):
DEBUG Can use sender key for 2/2 recipients.
INFO  Need to send the distribution message to 2 addresses.
DEBUG Sending took PT7.164S

# Message 2 (immediately after):
DEBUG Can use sender key for 2/2 recipients.
DEBUG Successfully sent using sender key to 2/2 sender key targets.
DEBUG Sending took PT6.059S
```

### Known remaining issue

A ~6s delay still occurs on every message due to a separate problem: the unidentified
(sealed sender) connection is torn down a few seconds after each send and must be
re-established for the next message:

```
[unidentified:1636243480] Connected      ← message sent
[unidentified:1636243480] Disconnecting  ← closed ~4s later
[unidentified:255738755]  Connecting     ← next message, new 6s wait
```

The authenticated connection is kept alive via periodic keep-alives; the unidentified
connection is not. Signal mobile clients maintain a persistent unidentified connection.
This is a separate issue in libsignal's connection management and is outside the scope
of this fix.