### PR TITLE
Add distinct JSON-RPC error code for captcha rejection

### DIFF
--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -1168,6 +1168,7 @@ signal-cli -a ACCOUNT trust -a RECIPIENT
 * *3*: Server or IO error
 * *4*: Sending failed due to untrusted key
 * *5*: Server rate limiting error
+* *6*: CAPTCHA was rejected
 
 == Files
 

--- a/src/main/java/org/asamk/signal/Main.java
+++ b/src/main/java/org/asamk/signal/Main.java
@@ -22,6 +22,7 @@ import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 
+import org.asamk.signal.commands.exceptions.CaptchaRejectedErrorException;
 import org.asamk.signal.commands.exceptions.CommandException;
 import org.asamk.signal.commands.exceptions.IOErrorException;
 import org.asamk.signal.commands.exceptions.RateLimitErrorException;
@@ -128,6 +129,7 @@ public class Main {
             case IOErrorException ioErrorException -> 3;
             case UntrustedKeyErrorException untrustedKeyErrorException -> 4;
             case RateLimitErrorException rateLimitErrorException -> 5;
+            case CaptchaRejectedErrorException captchaRejectedErrorException -> 6;
             case null -> 2;
         };
     }

--- a/src/main/java/org/asamk/signal/commands/SubmitRateLimitChallengeCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SubmitRateLimitChallengeCommand.java
@@ -3,9 +3,9 @@ package org.asamk.signal.commands;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
+import org.asamk.signal.commands.exceptions.CaptchaRejectedErrorException;
 import org.asamk.signal.commands.exceptions.CommandException;
 import org.asamk.signal.commands.exceptions.IOErrorException;
-import org.asamk.signal.commands.exceptions.UserErrorException;
 import org.asamk.signal.manager.Manager;
 import org.asamk.signal.manager.api.CaptchaRejectedException;
 import org.asamk.signal.output.OutputWriter;
@@ -41,8 +41,8 @@ public class SubmitRateLimitChallengeCommand implements JsonRpcLocalCommand {
         } catch (IOException e) {
             throw new IOErrorException("Submit challenge error: " + e.getMessage(), e);
         } catch (CaptchaRejectedException e) {
-            throw new UserErrorException(
-                    "Captcha rejected, it may be outdated, already used or solved from a different IP address.");
+            throw new CaptchaRejectedErrorException(
+                    "Captcha rejected, it may be outdated, already used or solved from a different IP address.", e);
         }
     }
 }

--- a/src/main/java/org/asamk/signal/commands/exceptions/CaptchaRejectedErrorException.java
+++ b/src/main/java/org/asamk/signal/commands/exceptions/CaptchaRejectedErrorException.java
@@ -1,0 +1,10 @@
+package org.asamk.signal.commands.exceptions;
+
+import org.asamk.signal.manager.api.CaptchaRejectedException;
+
+public final class CaptchaRejectedErrorException extends CommandException {
+
+    public CaptchaRejectedErrorException(final String message, final CaptchaRejectedException cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/asamk/signal/commands/exceptions/CommandException.java
+++ b/src/main/java/org/asamk/signal/commands/exceptions/CommandException.java
@@ -1,6 +1,6 @@
 package org.asamk.signal.commands.exceptions;
 
-public sealed abstract class CommandException extends Exception permits IOErrorException, RateLimitErrorException, UnexpectedErrorException, UntrustedKeyErrorException, UserErrorException {
+public sealed abstract class CommandException extends Exception permits CaptchaRejectedErrorException, IOErrorException, RateLimitErrorException, UnexpectedErrorException, UntrustedKeyErrorException, UserErrorException {
 
     public CommandException(final String message) {
         super(message);

--- a/src/main/java/org/asamk/signal/jsonrpc/SignalJsonRpcCommandHandler.java
+++ b/src/main/java/org/asamk/signal/jsonrpc/SignalJsonRpcCommandHandler.java
@@ -12,6 +12,7 @@ import org.asamk.signal.commands.Command;
 import org.asamk.signal.commands.JsonRpcMultiCommand;
 import org.asamk.signal.commands.JsonRpcRegistrationCommand;
 import org.asamk.signal.commands.JsonRpcSingleCommand;
+import org.asamk.signal.commands.exceptions.CaptchaRejectedErrorException;
 import org.asamk.signal.commands.exceptions.CommandException;
 import org.asamk.signal.commands.exceptions.IOErrorException;
 import org.asamk.signal.commands.exceptions.RateLimitErrorException;
@@ -39,6 +40,7 @@ public class SignalJsonRpcCommandHandler {
     private static final int IO_ERROR = -3;
     private static final int UNTRUSTED_KEY_ERROR = -4;
     private static final int RATELIMIT_ERROR = -5;
+    private static final int CAPTCHA_REJECTED_ERROR = -6;
 
     private final Manager m;
     private final MultiAccountManager c;
@@ -256,6 +258,10 @@ public class SignalJsonRpcCommandHandler {
                         e.getMessage(),
                         getErrorDataNode(objectMapper, result)));
                 case RateLimitErrorException e -> throw new JsonRpcException(new JsonRpcResponse.Error(RATELIMIT_ERROR,
+                        e.getMessage(),
+                        getErrorDataNode(objectMapper, result)));
+                case CaptchaRejectedErrorException e -> throw new JsonRpcException(new JsonRpcResponse.Error(
+                        CAPTCHA_REJECTED_ERROR,
                         e.getMessage(),
                         getErrorDataNode(objectMapper, result)));
                 case UnexpectedErrorException e -> {


### PR DESCRIPTION
## Problem

`submitRateLimitChallenge` currently maps `CaptchaRejectedException` to the generic `USER_ERROR` code (`-1`) in the JSON-RPC layer. This makes it impossible for callers to programmatically distinguish a rejected captcha token from any other user error (missing params, unknown method, etc.) without fragile string-matching on the error message.

## Solution

Introduce `CaptchaRejectedErrorException` and a dedicated error code (`-6` / `CAPTCHA_REJECTED_ERROR`). The change follows the same pattern as the existing `RateLimitErrorException` (`-5`).

**Before:**
```json
{ "error": { "code": -1, "message": "Captcha rejected, it may be outdated..." } }
```

**After:**
```json
{ "error": { "code": -6, "message": "Captcha rejected, it may be outdated..." } }
```

The error message is unchanged. The CLI exit code for this path becomes `6`, consistent with the per-error-type exit code convention.

## Changes

- `CaptchaRejectedErrorException.java` — new exception type mirroring `RateLimitErrorException`
- `CommandException.java` — adds `CaptchaRejectedErrorException` to the sealed `permits` clause
- `SubmitRateLimitChallengeCommand.java` — throws `CaptchaRejectedErrorException` instead of `UserErrorException`
- `SignalJsonRpcCommandHandler.java` — maps it to code `-6`
- `Main.java` — handles it in the CLI exit code switch (exit `6`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)