### PR TITLE
Store profile keys for group v2 requesting members

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/helper/GroupHelper.java
+++ b/lib/src/main/java/org/asamk/signal/manager/helper/GroupHelper.java
@@ -38,6 +38,8 @@ import org.signal.storageservice.storage.protos.groups.GroupChangeResponse;
 import org.signal.storageservice.storage.protos.groups.local.DecryptedGroup;
 import org.signal.storageservice.storage.protos.groups.local.DecryptedGroupChange;
 import org.signal.storageservice.storage.protos.groups.local.DecryptedGroupJoinInfo;
+import org.signal.storageservice.storage.protos.groups.local.DecryptedMember;
+import org.signal.storageservice.storage.protos.groups.local.DecryptedRequestingMember;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.whispersystems.signalservice.api.groupsv2.DecryptedGroupChangeLog;
@@ -557,17 +559,44 @@ public class GroupHelper {
 
     private void storeProfileKeysFromMembers(final DecryptedGroup group) {
         for (var member : group.members) {
-            final var serviceId = ServiceId.parseOrThrow(member.aciBytes);
-            final var recipientId = account.getRecipientResolver().resolveRecipient(serviceId);
-            final var profileStore = account.getProfileStore();
-            if (profileStore.getProfileKey(recipientId) != null) {
-                // We already have a profile key, not updating it from a non-authoritative source
-                continue;
-            }
-            try {
-                profileStore.storeProfileKey(recipientId, new ProfileKey(member.profileKey.toByteArray()));
-            } catch (InvalidInputException ignored) {
-            }
+            storeProfileKeyForDecryptedMemberIfMissing(member);
+        }
+        for (var member : group.requestingMembers) {
+            storeProfileKeyForDecryptedRequestingMemberIfMissing(member);
+        }
+    }
+
+    private void storeProfileKeyForDecryptedMemberIfMissing(final DecryptedMember member) {
+        if (member == null) {
+            return;
+        }
+        final var serviceId = ServiceId.parseOrThrow(member.aciBytes);
+        final var recipientId = account.getRecipientResolver().resolveRecipient(serviceId);
+        final var profileStore = account.getProfileStore();
+        if (profileStore.getProfileKey(recipientId) != null) {
+            // We already have a profile key, not updating it from a non-authoritative source
+            return;
+        }
+        try {
+            profileStore.storeProfileKey(recipientId, new ProfileKey(member.profileKey.toByteArray()));
+        } catch (InvalidInputException ignored) {
+        }
+    }
+
+    private void storeProfileKeyForDecryptedRequestingMemberIfMissing(final DecryptedRequestingMember member) {
+        if (member == null) {
+            return;
+        }
+        final var serviceId = ServiceId.parseOrThrow(member.aciBytes);
+        final var recipientId = account.getRecipientResolver().resolveRecipient(serviceId);
+        final var profileStore = account.getProfileStore();
+        if (profileStore.getProfileKey(recipientId) != null) {
+            // We already have a profile key, not updating it from a non-authoritative source
+            return;
+        }
+        try {
+            profileStore.storeProfileKey(recipientId, new ProfileKey(member.profileKey.toByteArray()));
+        } catch (InvalidInputException ignored) {
         }
     }
 


### PR DESCRIPTION
Fixes a gap where storeProfileKeysFromMembers only ingested profile keys from DecryptedGroup.members, not from equestingMembers (as DecryptedRequestingMember).

**Symptom:** After a group refresh, an admin (or signal-cli) that had not previously exchanged with someone in the join queue could not decrypt their profile, so e.g. \listContacts\ / UIs showed empty names for those requesters, while the official clients could still show them.

**Change:** Reuse the same store-if-missing logic for each requesting member, using the existing proto types so \libsignal-cli\ does not need a direct \com.google.protobuf\ compile dependency in \GroupHelper\.

**Testing:** We run this in a downstream Docker image; behavior verified against a real group with a pending join queue.

cc @AsamK

Made with [Cursor](https://cursor.com)