### PR TITLE
Skip known-unregistered recipients when sending to groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Sending to large groups is no longer slowed down by members that are already known to be unregistered; they are skipped instead of being retried via the legacy 1:1 send path on every send.
+
 ## [0.14.5] - 2026-06-11
 
 ### Changed

--- a/lib/src/main/java/org/asamk/signal/manager/helper/SendHelper.java
+++ b/lib/src/main/java/org/asamk/signal/manager/helper/SendHelper.java
@@ -507,9 +507,32 @@ public class SendHelper {
     ) throws IOException {
         long startTime = System.currentTimeMillis();
 
-        final var addressesMap = recipientIds.stream()
+        // Recipients that are already known to be unregistered are skipped here.
+        // Otherwise every group send re-attempts them via the slow legacy 1:1
+        // fan-out, which on large groups can take tens of seconds (and time out).
+        // The unregistered flag is maintained independently by profile/CDS
+        // discovery, which clears it once a recipient registers again, so they
+        // are re-included automatically. An unregisteredFailure result is still
+        // returned for each skipped recipient, so callers see them unchanged.
+        final var skippedResults = new ArrayList<SendMessageResult>();
+        final Set<RecipientId> targetRecipientIds;
+        final var unregisteredRecipientIds = account.getRecipientStore().getUnregisteredRecipientIds(recipientIds);
+        if (unregisteredRecipientIds.isEmpty()) {
+            targetRecipientIds = recipientIds;
+        } else {
+            logger.debug("Skipping {} known-unregistered recipient(s) in group send.",
+                    unregisteredRecipientIds.size());
+            targetRecipientIds = new HashSet<>(recipientIds);
+            targetRecipientIds.removeAll(unregisteredRecipientIds);
+            for (final var recipientId : unregisteredRecipientIds) {
+                skippedResults.add(SendMessageResult.unregisteredFailure(context.getRecipientHelper()
+                        .resolveSignalServiceAddress(recipientId)));
+            }
+        }
+
+        final var addressesMap = targetRecipientIds.stream()
                 .collect(Collectors.toMap(id -> id, context.getRecipientHelper()::resolveSignalServiceAddress));
-        final var unidentifiedAccessesMap = context.getUnidentifiedAccessHelper().getAccessFor(recipientIds);
+        final var unidentifiedAccessesMap = context.getUnidentifiedAccessHelper().getAccessFor(targetRecipientIds);
         final var groupSendEndorsementsResult = getGroupSendEndorsements(groupInfo);
         final var groupSecretParams = groupInfo instanceof GroupInfoV2 gv2
                 ? GroupSecretParams.deriveFromMasterKey((gv2.getMasterKey()))
@@ -523,7 +546,7 @@ public class SendHelper {
                 : groupSendEndorsementsResult.first();
         Set<RecipientId> senderKeyTargets = groupInfo.getDistributionId() == null || groupSendEndorsements == null
                 ? Set.of()
-                : recipientIds.stream()
+                : targetRecipientIds.stream()
                   .filter(s -> this.isSenderKeyCapable(s,
                           addressesMap.get(s),
                           unidentifiedAccessesMap.get(s),
@@ -533,7 +556,7 @@ public class SendHelper {
             logger.debug("Too few sender-key-capable users ({}). Doing all legacy sends.", senderKeyTargets.size());
             senderKeyTargets = Set.of();
         } else {
-            logger.debug("Can use sender key for {}/{} recipients.", senderKeyTargets.size(), recipientIds.size());
+            logger.debug("Can use sender key for {}/{} recipients.", senderKeyTargets.size(), targetRecipientIds.size());
         }
 
         final var allResults = new ArrayList<SendMessageResult>(recipientIds.size());
@@ -569,9 +592,9 @@ public class SendHelper {
             }
         }
 
-        final var legacyTargets = new HashSet<>(recipientIds);
+        final var legacyTargets = new HashSet<>(targetRecipientIds);
         legacyTargets.removeAll(senderKeyTargets);
-        final boolean onlyTargetIsSelfWithLinkedDevice = recipientIds.isEmpty() && account.isMultiDevice();
+        final boolean onlyTargetIsSelfWithLinkedDevice = targetRecipientIds.isEmpty() && account.isMultiDevice();
 
         if (!legacyTargets.isEmpty() || onlyTargetIsSelfWithLinkedDevice) {
             if (!legacyTargets.isEmpty()) {
@@ -605,6 +628,7 @@ public class SendHelper {
                     isRecipientUpdate || !allResults.isEmpty());
             allResults.addAll(results);
         }
+        allResults.addAll(skippedResults);
         final var duration = Duration.ofMillis(System.currentTimeMillis() - startTime);
         logger.debug("Sending took {}", duration.toString());
         return allResults;

--- a/lib/src/main/java/org/asamk/signal/manager/storage/recipients/RecipientStore.java
+++ b/lib/src/main/java/org/asamk/signal/manager/storage/recipients/RecipientStore.java
@@ -463,6 +463,40 @@ public class RecipientStore implements RecipientIdCreator, RecipientResolver, Re
         }
     }
 
+    /**
+     * Returns the subset of the given recipients that are currently known to be
+     * unregistered (i.e. have an unregistered timestamp set).
+     * <p>
+     * These can be skipped when sending group messages; otherwise every send
+     * re-attempts them via the slow legacy 1:1 fan-out. The unregistered flag is
+     * maintained independently by profile/CDS discovery and cleared again once a
+     * recipient registers, so they are re-included automatically.
+     */
+    public Set<RecipientId> getUnregisteredRecipientIds(final Set<RecipientId> recipientIds) {
+        if (recipientIds.isEmpty()) {
+            return Set.of();
+        }
+        final var recipientIdsCommaSeparated = recipientIds.stream()
+                .map(recipientId -> String.valueOf(recipientId.id()))
+                .collect(Collectors.joining(","));
+        final var sql = (
+                """
+                SELECT r._id
+                FROM %s r
+                WHERE r.unregistered_timestamp IS NOT NULL AND r._id IN (%s)
+                """
+        ).formatted(TABLE_RECIPIENT, recipientIdsCommaSeparated);
+        try (final var connection = database.getConnection()) {
+            try (final var statement = connection.prepareStatement(sql)) {
+                try (var result = Utils.executeQueryForStream(statement, this::getRecipientIdFromResultSet)) {
+                    return result.collect(Collectors.toSet());
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed read from recipient store", e);
+        }
+    }
+
     public Set<String> getAllNumbers() {
         final var sql = (
                 """


### PR DESCRIPTION
## Why

When sending to a group, signal-cli builds the recipient list from the **full** group membership and attempts delivery to every member. Members that are already known to be unregistered (they left Signal / deleted their account) are never excluded, so they are retried on **every** send.

For a group that has accumulated many such dead accounts, this forces signal-cli off the fast sealed-sender group path onto the legacy per-recipient (1:1) fan-out, and each unregistered recipient costs a failed network round-trip.

## What it breaks

On a real 143-member group containing **35 unregistered** members, a single send — even a typing indicator — took **~23.7 s**:

```
Successfully sent using 1:1 to 2/41 legacy targets.
Sending took PT23.704S
```

This is bad on its own, but it becomes a hard failure under `daemon --http`: the single-threaded daemon is blocked for the full ~23 s, a client/health-check timeout then tears the daemon down mid-send, the message is never delivered, and the daemon restarts — repeating for every send to that group. (There is no JVM crash / `hs_err`; it's a slow-send-gets-killed loop, which made it hard to diagnose.)

## The fix

Before sending a group message, filter out recipients whose `unregistered_timestamp` is already set, returning an `unregisteredFailure` result for each **without** the network attempt. Result reporting is unchanged — those recipients still appear as `UNREGISTERED_FAILURE` in the send results and CLI output; they are simply no longer dialed.

This is safe because the unregistered flag is maintained **independently** by profile/CDS discovery (`ProfileHelper`), which clears it via `markRegistered(..., true)` when a recipient registers again — so skipped recipients are automatically re-included. The send path itself neither sets nor clears the flag, so nothing is permanently blacklisted.

`sendGroupMessageInternal` is the single choke point that both data messages and typing indicators funnel through, so one filter covers every group send.

### Changes
- **`RecipientStore#getUnregisteredRecipientIds(Set<RecipientId>)`** — new query returning the subset of the given recipients that have `unregistered_timestamp` set.
- **`SendHelper#sendGroupMessageInternal`** — partition out known-unregistered recipients up front and emit their `unregisteredFailure` results without a network send.

## Testing

Built with `./gradlew installDist` (JDK 25) and exercised against the same 143-member group:

| | before | after |
|---|---|---|
| internal send time | `PT23.704S` | `PT2.405S` |
| `Hit unregistered user` network attempts | 35 | **0** |
| daemon RPC `sendTyping` | `HTTP 000`, daemon killed mid-send | `HTTP 200` in ~1.6 s, daemon survives |
| group send results | — | 104 `SUCCESS` / 35 `UNREGISTERED_FAILURE` / 3 `IDENTITY_FAILURE` |

Verbose output confirms the new path: `Skipping 35 known-unregistered recipient(s) in group send.`
