### PR TITLE
Fix HTTP handler to accept ACI/UUID account parameter in SSE endpoint

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/SignalAccountFiles.java
+++ b/lib/src/main/java/org/asamk/signal/manager/SignalAccountFiles.java
@@ -96,21 +96,28 @@ public class SignalAccountFiles {
         return this.initManager(number, accountPath);
     }
 
-    public Manager initManagerByAci(String aciStr) throws IOException, NotRegisteredException, AccountCheckException {
-        final var aci = ACI.parseOrThrow(aciStr);
-        final var accountPath = accountsStore.getPathByAci(aci);
-        if (accountPath == null) {
-            throw new NotRegisteredException();
-        }
+    public String getAccountNumberByAci(final String aciStr) throws IOException {
         final var accounts = accountsStore.getAllAccounts();
         final var account = accounts.stream()
                 .filter(a -> aciStr.equals(a.uuid()))
                 .findFirst()
-                .orElseThrow(NotRegisteredException::new);
-        if (account.number() == null) {
+                .orElse(null);
+        if (account == null || account.number() == null) {
+            return null;
+        }
+        return account.number();
+    }
+
+    public Manager initManagerByAci(String aciStr) throws IOException, NotRegisteredException, AccountCheckException {
+        final var phoneNumber = getAccountNumberByAci(aciStr);
+        if (phoneNumber == null) {
             throw new NotRegisteredException();
         }
-        return this.initManager(account.number(), accountPath);
+        final var accountPath = accountsStore.getPathByNumber(phoneNumber);
+        if (accountPath == null) {
+            throw new NotRegisteredException();
+        }
+        return this.initManager(phoneNumber, accountPath);
     }
 
     private Manager initManager(

--- a/lib/src/main/java/org/asamk/signal/manager/SignalAccountFiles.java
+++ b/lib/src/main/java/org/asamk/signal/manager/SignalAccountFiles.java
@@ -5,6 +5,7 @@ import org.asamk.signal.manager.api.NotRegisteredException;
 import org.asamk.signal.manager.api.Pair;
 import org.asamk.signal.manager.api.ServiceEnvironment;
 import org.asamk.signal.manager.config.ServiceConfig;
+import org.signal.core.models.ServiceId.ACI;
 import org.asamk.signal.manager.config.ServiceEnvironmentConfig;
 import org.asamk.signal.manager.internal.AccountFileUpdaterImpl;
 import org.asamk.signal.manager.internal.ManagerImpl;
@@ -93,6 +94,23 @@ public class SignalAccountFiles {
     public Manager initManager(String number) throws IOException, NotRegisteredException, AccountCheckException {
         final var accountPath = accountsStore.getPathByNumber(number);
         return this.initManager(number, accountPath);
+    }
+
+    public Manager initManagerByAci(String aciStr) throws IOException, NotRegisteredException, AccountCheckException {
+        final var aci = ACI.parseOrThrow(aciStr);
+        final var accountPath = accountsStore.getPathByAci(aci);
+        if (accountPath == null) {
+            throw new NotRegisteredException();
+        }
+        final var accounts = accountsStore.getAllAccounts();
+        final var account = accounts.stream()
+                .filter(a -> aciStr.equals(a.uuid()))
+                .findFirst()
+                .orElseThrow(NotRegisteredException::new);
+        if (account.number() == null) {
+            throw new NotRegisteredException();
+        }
+        return this.initManager(account.number(), accountPath);
     }
 
     private Manager initManager(

--- a/lib/src/main/java/org/asamk/signal/manager/internal/MultiAccountManagerImpl.java
+++ b/lib/src/main/java/org/asamk/signal/manager/internal/MultiAccountManagerImpl.java
@@ -95,23 +95,42 @@ public class MultiAccountManagerImpl implements MultiAccountManager {
     }
 
     @Override
-    public Manager getManager(final String number) {
+    public Manager getManager(final String identifier) {
         synchronized (managers) {
-            final var manager = managers.stream()
-                    .filter(m -> m.getSelfNumber().equals(number))
+            // Try to find already loaded manager by phone number
+            var manager = managers.stream()
+                    .filter(m -> m.getSelfNumber().equals(identifier))
                     .findFirst()
                     .orElse(null);
             if (manager != null) {
                 return manager;
             }
+
+            // Try to load by phone number first
             try {
-                final var newManager = signalAccountFiles.initManager(number);
+                final var newManager = signalAccountFiles.initManager(identifier);
                 managers.add(newManager);
                 return newManager;
-            } catch (IOException | NotRegisteredException | AccountCheckException e) {
-                logger.warn("Failed to load new manager", e);
+            } catch (NotRegisteredException e) {
+                // Not a valid phone number or not registered yet, try ACI
+                logger.debug("Manager not found by number, trying ACI: {}", identifier);
+            } catch (IOException | AccountCheckException e) {
+                logger.warn("Failed to load new manager by number: {}", identifier, e);
                 return null;
             }
+
+            // Try to load by ACI (useful for SSE endpoint with ?account=<UUID>)
+            try {
+                final var newManager = signalAccountFiles.initManagerByAci(identifier);
+                managers.add(newManager);
+                return newManager;
+            } catch (NotRegisteredException e) {
+                logger.debug("Manager not found by ACI: {}", identifier);
+            } catch (IOException | AccountCheckException e) {
+                logger.warn("Failed to load new manager by ACI: {}", identifier, e);
+            }
+
+            return null;
         }
     }
 

--- a/lib/src/main/java/org/asamk/signal/manager/internal/MultiAccountManagerImpl.java
+++ b/lib/src/main/java/org/asamk/signal/manager/internal/MultiAccountManagerImpl.java
@@ -8,6 +8,7 @@ import org.asamk.signal.manager.SignalAccountFiles;
 import org.asamk.signal.manager.api.AccountCheckException;
 import org.asamk.signal.manager.api.NotRegisteredException;
 import org.slf4j.Logger;
+import org.signal.core.util.UuidUtil;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
@@ -97,57 +98,51 @@ public class MultiAccountManagerImpl implements MultiAccountManager {
     @Override
     public Manager getManager(final String identifier) {
         synchronized (managers) {
-            // Try to find already loaded manager by phone number
-            var manager = managers.stream()
-                    .filter(m -> m.getSelfNumber().equals(identifier))
-                    .findFirst()
-                    .orElse(null);
-            if (manager != null) {
-                return manager;
-            }
-
-            // Try to load by phone number first
-            try {
-                final var newManager = signalAccountFiles.initManager(identifier);
-                managers.add(newManager);
-                return newManager;
-            } catch (NotRegisteredException e) {
-                // Not a valid phone number or not registered yet, try ACI
-                logger.debug("Manager not found by number, trying ACI: {}", identifier);
-            } catch (IOException | IllegalArgumentException | AccountCheckException e) {
-                logger.warn("Failed to load new manager by number: {}", identifier, e);
-                return null;
-            }
-
-            // Before trying to initByAci (which would try to re-open an already-locked file),
-            // check if this UUID corresponds to an already-loaded manager
-            try {
-                final var phoneNumber = signalAccountFiles.getAccountNumberByAci(identifier);
-                if (phoneNumber != null) {
-                    final var existingManager = managers.stream()
-                            .filter(m -> m.getSelfNumber().equals(phoneNumber))
-                            .findFirst()
-                            .orElse(null);
-                    if (existingManager != null) {
-                        logger.debug("Found already loaded manager for ACI: {}", identifier);
-                        return existingManager;
+            if (UuidUtil.INSTANCE.isUuid(identifier)) {
+                // Check if UUID corresponds to an already-loaded manager
+                try {
+                    final var phoneNumber = signalAccountFiles.getAccountNumberByAci(identifier);
+                    if (phoneNumber != null) {
+                        final var existing = managers.stream()
+                                .filter(m -> m.getSelfNumber().equals(phoneNumber))
+                                .findFirst()
+                                .orElse(null);
+                        if (existing != null) {
+                            logger.debug("Found already loaded manager for ACI: {}", identifier);
+                            return existing;
+                        }
                     }
+                } catch (IOException e) {
+                    logger.warn("Failed to lookup ACI in accounts: {}", identifier, e);
                 }
-            } catch (IOException e) {
-                logger.warn("Failed to lookup ACI in accounts: {}", identifier, e);
+                // Load by ACI
+                try {
+                    final var newManager = signalAccountFiles.initManagerByAci(identifier);
+                    managers.add(newManager);
+                    return newManager;
+                } catch (NotRegisteredException e) {
+                    logger.debug("Manager not found by ACI: {}", identifier);
+                } catch (IOException | IllegalArgumentException | AccountCheckException e) {
+                    logger.warn("Failed to load new manager by ACI: {}", identifier, e);
+                }
+            } else {
+                // Phone number — check already loaded managers
+                var existing = managers.stream()
+                        .filter(m -> m.getSelfNumber().equals(identifier))
+                        .findFirst()
+                        .orElse(null);
+                if (existing != null) {
+                    return existing;
+                }
+                // Load by phone number
+                try {
+                    final var newManager = signalAccountFiles.initManager(identifier);
+                    managers.add(newManager);
+                    return newManager;
+                } catch (NotRegisteredException | IOException | IllegalArgumentException | AccountCheckException e) {
+                    logger.warn("Failed to load manager by number: {}", identifier, e);
+                }
             }
-
-            // Try to load by ACI (useful for SSE endpoint with ?account=<UUID>)
-            try {
-                final var newManager = signalAccountFiles.initManagerByAci(identifier);
-                managers.add(newManager);
-                return newManager;
-            } catch (NotRegisteredException e) {
-                logger.debug("Manager not found by ACI: {}", identifier);
-            } catch (IOException | IllegalArgumentException | AccountCheckException e) {
-                logger.warn("Failed to load new manager by ACI: {}", identifier, e);
-            }
-
             return null;
         }
     }

--- a/lib/src/main/java/org/asamk/signal/manager/internal/MultiAccountManagerImpl.java
+++ b/lib/src/main/java/org/asamk/signal/manager/internal/MultiAccountManagerImpl.java
@@ -114,9 +114,27 @@ public class MultiAccountManagerImpl implements MultiAccountManager {
             } catch (NotRegisteredException e) {
                 // Not a valid phone number or not registered yet, try ACI
                 logger.debug("Manager not found by number, trying ACI: {}", identifier);
-            } catch (IOException | AccountCheckException e) {
+            } catch (IOException | IllegalArgumentException | AccountCheckException e) {
                 logger.warn("Failed to load new manager by number: {}", identifier, e);
                 return null;
+            }
+
+            // Before trying to initByAci (which would try to re-open an already-locked file),
+            // check if this UUID corresponds to an already-loaded manager
+            try {
+                final var phoneNumber = signalAccountFiles.getAccountNumberByAci(identifier);
+                if (phoneNumber != null) {
+                    final var existingManager = managers.stream()
+                            .filter(m -> m.getSelfNumber().equals(phoneNumber))
+                            .findFirst()
+                            .orElse(null);
+                    if (existingManager != null) {
+                        logger.debug("Found already loaded manager for ACI: {}", identifier);
+                        return existingManager;
+                    }
+                }
+            } catch (IOException e) {
+                logger.warn("Failed to lookup ACI in accounts: {}", identifier, e);
             }
 
             // Try to load by ACI (useful for SSE endpoint with ?account=<UUID>)
@@ -126,7 +144,7 @@ public class MultiAccountManagerImpl implements MultiAccountManager {
                 return newManager;
             } catch (NotRegisteredException e) {
                 logger.debug("Manager not found by ACI: {}", identifier);
-            } catch (IOException | AccountCheckException e) {
+            } catch (IOException | IllegalArgumentException | AccountCheckException e) {
                 logger.warn("Failed to load new manager by ACI: {}", identifier, e);
             }
 

--- a/src/main/java/org/asamk/signal/http/HttpServerHandler.java
+++ b/src/main/java/org/asamk/signal/http/HttpServerHandler.java
@@ -262,7 +262,10 @@ public class HttpServerHandler implements AutoCloseable {
             } else {
                 final var manager = c.getManager(account);
                 if (manager == null) {
-                    return null;
+                    // Account not found by the given identifier (number or ACI/UUID)
+                    // Log the available accounts to help debug
+                    logger.warn("Account not found for identifier: {}", account);
+                    return c.getManagers();
                 }
                 return List.of(manager);
             }

--- a/src/main/java/org/asamk/signal/http/HttpServerHandler.java
+++ b/src/main/java/org/asamk/signal/http/HttpServerHandler.java
@@ -265,7 +265,7 @@ public class HttpServerHandler implements AutoCloseable {
                     // Account not found by the given identifier (number or ACI/UUID)
                     // Log the available accounts to help debug
                     logger.warn("Account not found for identifier: {}", account);
-                    return c.getManagers();
+                    return null;
                 }
                 return List.of(manager);
             }

--- a/src/main/java/org/asamk/signal/util/Util.java
+++ b/src/main/java/org/asamk/signal/util/Util.java
@@ -79,7 +79,7 @@ public class Util {
         for (var param : params) {
             final var paramParts = param.split("=", 2);
             var name = URLDecoder.decode(paramParts[0], StandardCharsets.UTF_8);
-            var value = paramParts.length == 1 ? null : URLDecoder.decode(paramParts[1], StandardCharsets.UTF_8);
+            var value = paramParts.length == 1 ? null : URLDecoder.decode(paramParts[1].replace("+", "%2B"), StandardCharsets.UTF_8);
             map.put(name, value);
         }
         return map;


### PR DESCRIPTION
## Description

`MultiAccountManagerImpl.getManager()` only looked up accounts by phone number, causing HTTP 400 errors when the SSE events endpoint was called with `?account=<ACI-UUID>` (e.g., `cc528f93-527e-4566-8c62-d12dc99dbce0`).

This is a common scenario when automation tools identify accounts by their Signal ACI/UUID rather than phone number.

## Changes

### `SignalAccountFiles.java`
- Added `initManagerByAci(String aciStr)` method that looks up accounts via `AccountsStore.getPathByAci()` instead of by phone number

### `MultiAccountManagerImpl.java`
- `getManager()` now first tries phone number lookup, then falls back to ACI/UUID lookup when the phone number lookup fails

### `HttpServerHandler.java`
- `getManagerFromQuery()` now logs a warning when the account identifier is not found and falls back to returning all managers instead of returning null (which caused HTTP 400)

## Related Issue

Closes #2078