### PR TITLE
Add sendStory command for posting file attachment stories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- New `sendStory` command to post file attachment stories to "My Story"
+
 ### Fixed
 
 - Sending to large groups is no longer slowed down by members that are already known to be unregistered; they are skipped instead of being retried via the legacy 1:1 send path on every send.

--- a/lib/src/main/java/org/asamk/signal/manager/Manager.java
+++ b/lib/src/main/java/org/asamk/signal/manager/Manager.java
@@ -213,6 +213,14 @@ public interface Manager extends Closeable {
             long editTargetTimestamp
     ) throws IOException, AttachmentInvalidException, NotAGroupMemberException, GroupNotFoundException, GroupSendingNotAllowedException, UnregisteredRecipientException, InvalidStickerException;
 
+    /**
+     * Post a file attachment story to "My Story".
+     *
+     * @param attachment    path to the file to upload and post as a story
+     * @param allowsReplies whether other users are allowed to reply to this story
+     */
+    SendMessageResults sendStory(String attachment, boolean allowsReplies) throws IOException, AttachmentInvalidException;
+
     SendMessageResults sendRemoteDeleteMessage(
             long targetSentTimestamp,
             Set<RecipientIdentifier> recipients

--- a/lib/src/main/java/org/asamk/signal/manager/helper/SendHelper.java
+++ b/lib/src/main/java/org/asamk/signal/manager/helper/SendHelper.java
@@ -35,6 +35,8 @@ import org.whispersystems.signalservice.api.messages.SendMessageResult;
 import org.whispersystems.signalservice.api.messages.SignalServiceDataMessage;
 import org.whispersystems.signalservice.api.messages.SignalServiceEditMessage;
 import org.whispersystems.signalservice.api.messages.SignalServiceReceiptMessage;
+import org.whispersystems.signalservice.api.messages.SignalServiceStoryMessage;
+import org.whispersystems.signalservice.api.messages.SignalServiceStoryMessageRecipient;
 import org.whispersystems.signalservice.api.messages.SignalServiceTypingMessage;
 import org.whispersystems.signalservice.api.messages.calls.SignalServiceCallMessage;
 import org.whispersystems.signalservice.api.messages.multidevice.SentTranscriptMessage;
@@ -328,6 +330,53 @@ public class SendHelper {
         }
         handleSendMessageResult(result);
         return result;
+    }
+
+    /**
+     * Send a story message (file attachment) to "My Story".
+     */
+    public List<SendMessageResult> sendStoryMessage(
+            SignalServiceStoryMessage storyMessage,
+            long timestamp,
+            Set<RecipientId> recipientIds,
+            boolean allowsReplies
+    ) throws IOException {
+        final var messageSender = dependencies.getMessageSender();
+
+        final var recipientIdList = List.copyOf(recipientIds);
+        final var addressesMap = recipientIdList.stream()
+                .collect(Collectors.toMap(id -> id, context.getRecipientHelper()::resolveSignalServiceAddress));
+        final var unidentifiedAccessesMap = context.getUnidentifiedAccessHelper().getAccessFor(recipientIds);
+
+        final var addresses = recipientIdList.stream().map(addressesMap::get).toList();
+        final var unidentifiedAccesses = recipientIdList.stream().map(unidentifiedAccessesMap::get).toList();
+        final var storyMessageRecipients = recipientIdList.stream()
+                .map(id -> new SignalServiceStoryMessageRecipient(addressesMap.get(id),
+                        List.of(DistributionId.MY_STORY.asUuid().toString()),
+                        allowsReplies))
+                .collect(Collectors.toSet());
+
+        final List<SendMessageResult> results;
+        try {
+            results = messageSender.sendGroupStory(DistributionId.MY_STORY,
+                    Optional.empty(),
+                    addresses,
+                    unidentifiedAccesses,
+                    null,
+                    false,
+                    storyMessage,
+                    timestamp,
+                    storyMessageRecipients,
+                    null);
+        } catch (UntrustedIdentityException | InvalidKeyException | NoSessionException | InvalidRegistrationIdException e) {
+            throw new IOException(e);
+        }
+
+        for (var r : results) {
+            handleSendMessageResult(r);
+        }
+
+        return results;
     }
 
     private List<SendMessageResult> sendAsGroupMessage(

--- a/lib/src/main/java/org/asamk/signal/manager/internal/ManagerImpl.java
+++ b/lib/src/main/java/org/asamk/signal/manager/internal/ManagerImpl.java
@@ -110,7 +110,6 @@ import org.whispersystems.signalservice.api.messages.SignalServiceDataMessage;
 import org.whispersystems.signalservice.api.messages.SignalServicePreview;
 import org.whispersystems.signalservice.api.messages.SignalServiceReceiptMessage;
 import org.whispersystems.signalservice.api.messages.SignalServiceStoryMessage;
-import org.whispersystems.signalservice.api.messages.SignalServiceStoryMessageRecipient;
 import org.whispersystems.signalservice.api.messages.SignalServiceTypingMessage;
 import org.whispersystems.signalservice.api.messages.calls.AnswerMessage;
 import org.whispersystems.signalservice.api.messages.calls.BusyMessage;
@@ -119,7 +118,6 @@ import org.whispersystems.signalservice.api.messages.calls.IceUpdateMessage;
 import org.whispersystems.signalservice.api.messages.calls.OfferMessage;
 import org.whispersystems.signalservice.api.messages.calls.SignalServiceCallMessage;
 import org.whispersystems.signalservice.api.messages.multidevice.DeviceInfo;
-import org.whispersystems.signalservice.api.push.DistributionId;
 import org.whispersystems.signalservice.api.push.ServiceIdType;
 import org.whispersystems.signalservice.api.push.exceptions.CdsiResourceExhaustedException;
 import org.whispersystems.signalservice.api.util.DeviceNameUtil;
@@ -846,7 +844,7 @@ public class ManagerImpl implements Manager {
                 .getRecipients(true, Optional.of(false), Set.of(), Optional.empty());
         final var recipientIds = recipients.stream()
                 .filter(r -> !r.getRecipientId().equals(account.getSelfRecipientId()))
-                .filter(r -> r.getContact() == null || !r.getContact().hideStory())
+                .filter(r -> r.getContact() != null && !r.getContact().hideStory())
                 .map(r -> r.getRecipientId())
                 .collect(Collectors.toSet());
 
@@ -864,18 +862,6 @@ public class ManagerImpl implements Manager {
 
         final var sendResults = context.getSendHelper()
                 .sendStoryMessage(storyMessage, timestamp, recipientIds, allowsReplies);
-
-        final var storyMessageRecipients = sendResults.stream()
-                .filter(org.whispersystems.signalservice.api.messages.SendMessageResult::isSuccess)
-                .map(r -> new SignalServiceStoryMessageRecipient(r.getAddress(),
-                        List.of(DistributionId.MY_STORY.asUuid().toString()),
-                        allowsReplies))
-                .collect(Collectors.toSet());
-        try {
-            dependencies.getMessageSender().sendStorySyncMessage(storyMessage, timestamp, false, storyMessageRecipients);
-        } catch (UntrustedIdentityException e) {
-            throw new IOException(e);
-        }
 
         final var results = new HashMap<RecipientIdentifier, List<SendMessageResult>>();
         for (final var sendResult : sendResults) {

--- a/lib/src/main/java/org/asamk/signal/manager/internal/ManagerImpl.java
+++ b/lib/src/main/java/org/asamk/signal/manager/internal/ManagerImpl.java
@@ -841,13 +841,6 @@ public class ManagerImpl implements Manager {
             throw new AttachmentInvalidException(attachment,
                     new IOException("Stories only support image and video attachments"));
         }
-        final var uploadedAttachment = context.getAttachmentHelper().uploadAttachment(attachment);
-        final var storyMessage = SignalServiceStoryMessage.forFileAttachment(account.getProfileKey().serialize(),
-                null,
-                uploadedAttachment,
-                allowsReplies,
-                List.of());
-        final var timestamp = getNextMessageTimestamp();
 
         final var recipients = account.getRecipientStore()
                 .getRecipients(true, Optional.of(false), Set.of(), Optional.empty());
@@ -856,6 +849,18 @@ public class ManagerImpl implements Manager {
                 .filter(r -> r.getContact() == null || !r.getContact().hideStory())
                 .map(r -> r.getRecipientId())
                 .collect(Collectors.toSet());
+
+        if (recipientIds.isEmpty()) {
+            throw new IOException("No eligible contacts found for story delivery");
+        }
+
+        final var uploadedAttachment = context.getAttachmentHelper().uploadAttachment(attachment);
+        final var storyMessage = SignalServiceStoryMessage.forFileAttachment(account.getProfileKey().serialize(),
+                null,
+                uploadedAttachment,
+                allowsReplies,
+                List.of());
+        final var timestamp = getNextMessageTimestamp();
 
         final var sendResults = context.getSendHelper()
                 .sendStoryMessage(storyMessage, timestamp, recipientIds, allowsReplies);

--- a/lib/src/main/java/org/asamk/signal/manager/internal/ManagerImpl.java
+++ b/lib/src/main/java/org/asamk/signal/manager/internal/ManagerImpl.java
@@ -835,6 +835,12 @@ public class ManagerImpl implements Manager {
             String attachment,
             boolean allowsReplies
     ) throws IOException, AttachmentInvalidException {
+        final var file = new File(attachment);
+        final var mimeType = MimeUtils.getFileMimeType(file);
+        if (mimeType.isEmpty() || (!mimeType.get().startsWith("image/") && !mimeType.get().startsWith("video/"))) {
+            throw new AttachmentInvalidException(attachment,
+                    new IOException("Stories only support image and video attachments"));
+        }
         final var uploadedAttachment = context.getAttachmentHelper().uploadAttachment(attachment);
         final var storyMessage = SignalServiceStoryMessage.forFileAttachment(account.getProfileKey().serialize(),
                 null,

--- a/lib/src/main/java/org/asamk/signal/manager/internal/ManagerImpl.java
+++ b/lib/src/main/java/org/asamk/signal/manager/internal/ManagerImpl.java
@@ -104,10 +104,13 @@ import org.signal.libsignal.usernames.BaseUsernameException;
 import org.signal.network.exceptions.NonSuccessfulResponseCodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.whispersystems.signalservice.api.crypto.UntrustedIdentityException;
 import org.whispersystems.signalservice.api.messages.SignalServiceAttachment;
 import org.whispersystems.signalservice.api.messages.SignalServiceDataMessage;
 import org.whispersystems.signalservice.api.messages.SignalServicePreview;
 import org.whispersystems.signalservice.api.messages.SignalServiceReceiptMessage;
+import org.whispersystems.signalservice.api.messages.SignalServiceStoryMessage;
+import org.whispersystems.signalservice.api.messages.SignalServiceStoryMessageRecipient;
 import org.whispersystems.signalservice.api.messages.SignalServiceTypingMessage;
 import org.whispersystems.signalservice.api.messages.calls.AnswerMessage;
 import org.whispersystems.signalservice.api.messages.calls.BusyMessage;
@@ -116,6 +119,7 @@ import org.whispersystems.signalservice.api.messages.calls.IceUpdateMessage;
 import org.whispersystems.signalservice.api.messages.calls.OfferMessage;
 import org.whispersystems.signalservice.api.messages.calls.SignalServiceCallMessage;
 import org.whispersystems.signalservice.api.messages.multidevice.DeviceInfo;
+import org.whispersystems.signalservice.api.push.DistributionId;
 import org.whispersystems.signalservice.api.push.ServiceIdType;
 import org.whispersystems.signalservice.api.push.exceptions.CdsiResourceExhaustedException;
 import org.whispersystems.signalservice.api.util.DeviceNameUtil;
@@ -824,6 +828,51 @@ public class ManagerImpl implements Manager {
         final var messageBuilder = SignalServiceDataMessage.newBuilder();
         applyMessage(messageBuilder, message);
         return sendMessage(messageBuilder, recipients, false, Optional.of(editTargetTimestamp), message.urgent());
+    }
+
+    @Override
+    public SendMessageResults sendStory(
+            String attachment,
+            boolean allowsReplies
+    ) throws IOException, AttachmentInvalidException {
+        final var uploadedAttachment = context.getAttachmentHelper().uploadAttachment(attachment);
+        final var storyMessage = SignalServiceStoryMessage.forFileAttachment(account.getProfileKey().serialize(),
+                null,
+                uploadedAttachment,
+                allowsReplies,
+                List.of());
+        final var timestamp = getNextMessageTimestamp();
+
+        final var recipients = account.getRecipientStore()
+                .getRecipients(true, Optional.of(false), Set.of(), Optional.empty());
+        final var recipientIds = recipients.stream()
+                .filter(r -> !r.getRecipientId().equals(account.getSelfRecipientId()))
+                .filter(r -> r.getContact() == null || !r.getContact().hideStory())
+                .map(r -> r.getRecipientId())
+                .collect(Collectors.toSet());
+
+        final var sendResults = context.getSendHelper()
+                .sendStoryMessage(storyMessage, timestamp, recipientIds, allowsReplies);
+
+        final var storyMessageRecipients = sendResults.stream()
+                .filter(org.whispersystems.signalservice.api.messages.SendMessageResult::isSuccess)
+                .map(r -> new SignalServiceStoryMessageRecipient(r.getAddress(),
+                        List.of(DistributionId.MY_STORY.asUuid().toString()),
+                        allowsReplies))
+                .collect(Collectors.toSet());
+        try {
+            dependencies.getMessageSender().sendStorySyncMessage(storyMessage, timestamp, false, storyMessageRecipients);
+        } catch (UntrustedIdentityException e) {
+            throw new IOException(e);
+        }
+
+        final var results = new HashMap<RecipientIdentifier, List<SendMessageResult>>();
+        for (final var sendResult : sendResults) {
+            final var result = toSendMessageResult(sendResult);
+            results.put(RecipientIdentifier.Single.fromAddress(result.address()), List.of(result));
+        }
+
+        return new SendMessageResults(timestamp, results);
     }
 
     private void applyMessage(

--- a/man/signal-cli.1.adoc
+++ b/man/signal-cli.1.adoc
@@ -632,6 +632,16 @@ Specify the timestamp of the message to which to react.
 *--type* TYPE::
 Specify the receipt type, either `read` (the default) or `viewed`.
 
+=== sendStory
+
+Post a file attachment story to your Story, visible to all contacts.
+
+*-a* ATTACHMENT, *--attachment* ATTACHMENT::
+Specify the file path to the image or video to post as a story.
+
+*--no-replies*::
+Disable replies on this story. By default, replies are allowed.
+
 === sendTyping
 
 Send typing message to trigger a typing indicator for the recipient.

--- a/src/main/java/org/asamk/signal/commands/Commands.java
+++ b/src/main/java/org/asamk/signal/commands/Commands.java
@@ -52,6 +52,7 @@ public class Commands {
         addCommand(new SendPollTerminateCommand());
         addCommand(new SendReactionCommand());
         addCommand(new SendReceiptCommand());
+        addCommand(new SendStoryCommand());
         addCommand(new SendSyncRequestCommand());
         addCommand(new SendTypingCommand());
         addCommand(new SendUnpinMessageCommand());

--- a/src/main/java/org/asamk/signal/commands/SendStoryCommand.java
+++ b/src/main/java/org/asamk/signal/commands/SendStoryCommand.java
@@ -1,0 +1,57 @@
+package org.asamk.signal.commands;
+
+import net.sourceforge.argparse4j.impl.Arguments;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+
+import org.asamk.signal.commands.exceptions.CommandException;
+import org.asamk.signal.commands.exceptions.UnexpectedErrorException;
+import org.asamk.signal.commands.exceptions.UserErrorException;
+import org.asamk.signal.manager.Manager;
+import org.asamk.signal.manager.api.AttachmentInvalidException;
+import org.asamk.signal.output.OutputWriter;
+
+import java.io.IOException;
+
+import static org.asamk.signal.util.SendMessageResultUtils.outputResult;
+
+public class SendStoryCommand implements JsonRpcLocalCommand {
+
+    @Override
+    public String getName() {
+        return "sendStory";
+    }
+
+    @Override
+    public void attachToSubparser(final Subparser subparser) {
+        subparser.help("Post a story to your Story.");
+        subparser.addArgument("-a", "--attachment")
+                .required(true)
+                .help("Specify the file path to the image or video to post as a story.");
+        subparser.addArgument("--no-replies")
+                .action(Arguments.storeTrue())
+                .help("Disable replies on this story.");
+    }
+
+    @Override
+    public void handleCommand(
+            final Namespace ns,
+            final Manager m,
+            final OutputWriter outputWriter
+    ) throws CommandException {
+        final var attachment = ns.getString("attachment");
+        if (attachment == null || attachment.isEmpty()) {
+            throw new UserErrorException("An attachment is required for sending a story.");
+        }
+
+        final var noReplies = Boolean.TRUE.equals(ns.getBoolean("no-replies"));
+
+        try {
+            final var results = m.sendStory(attachment, !noReplies);
+            outputResult(outputWriter, results);
+        } catch (AttachmentInvalidException | IOException e) {
+            throw new UnexpectedErrorException("Failed to send story: " + e.getMessage() + " (" + e.getClass()
+                    .getSimpleName() + ")", e);
+        }
+    }
+}

--- a/src/main/java/org/asamk/signal/dbus/DbusManagerImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusManagerImpl.java
@@ -543,6 +543,11 @@ public class DbusManagerImpl implements Manager {
     }
 
     @Override
+    public SendMessageResults sendStory(String attachment, boolean allowsReplies) {
+        return new SendMessageResults(0, Map.of());
+    }
+
+    @Override
     public void sendEndSessionMessage(final Set<RecipientIdentifier.Single> recipients) throws IOException {
         signal.sendEndSessionMessage(recipients.stream().map(RecipientIdentifier.Single::getIdentifier).toList());
     }

--- a/src/main/java/org/asamk/signal/dbus/DbusManagerImpl.java
+++ b/src/main/java/org/asamk/signal/dbus/DbusManagerImpl.java
@@ -544,7 +544,7 @@ public class DbusManagerImpl implements Manager {
 
     @Override
     public SendMessageResults sendStory(String attachment, boolean allowsReplies) {
-        return new SendMessageResults(0, Map.of());
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/test/java/org/asamk/signal/http/SseInitialFlushTest.java
+++ b/src/test/java/org/asamk/signal/http/SseInitialFlushTest.java
@@ -350,6 +350,11 @@ class SseInitialFlushTest {
         }
 
         @Override
+        public SendMessageResults sendStory(String attachment, boolean allowsReplies) {
+            return new SendMessageResults(0, Map.of());
+        }
+
+        @Override
         public void hideRecipient(RecipientIdentifier.Single recipient) {
         }
 

--- a/src/test/java/org/asamk/signal/jsonrpc/SubscribeCallEventsTest.java
+++ b/src/test/java/org/asamk/signal/jsonrpc/SubscribeCallEventsTest.java
@@ -368,6 +368,11 @@ class SubscribeCallEventsTest {
         }
 
         @Override
+        public SendMessageResults sendStory(String attachment, boolean allowsReplies) {
+            return new SendMessageResults(0, Map.of());
+        }
+
+        @Override
         public void hideRecipient(RecipientIdentifier.Single r) {
         }
 


### PR DESCRIPTION
## Summary

- Add `sendStory` command to post a file attachment story (image/video) to "My Story" (all contacts)
- Supports `--attachment` (required) and `--no-replies` (optional) arguments
- Works in both CLI and JSON-RPC modes
- Validates attachment MIME type (image/video only) before uploading
- Resolves eligible recipients before uploading to avoid wasted bandwidth on empty contact lists
- Sends multi-device sync transcript after delivery

Addresses #1592. Takes a different approach from #1713 — sends to `DistributionId.MY_STORY` (individual contacts via sender keys) rather than group stories, which avoids the group send endorsements blocker that stalled the prior attempt.

### CLI usage
```
signal-cli -a +1234567890 sendStory -a /path/to/image.jpg
signal-cli -a +1234567890 sendStory -a /path/to/video.mp4 --no-replies
```

### JSON-RPC usage
```json
{"jsonrpc":"2.0","method":"sendStory","id":"1","params":{"attachment":"/path/to/image.jpg"}}
```

### Scope

This is Phase 1 — file attachment stories to "My Story" only. Future phases could add:
- Text stories (styled text cards)
- Group story targeting
- Custom distribution list management

## Test plan

- [x] `:lib:compileJava` passes
- [x] `:compileJava` and `:compileTestJava` pass (full project)
- [x] `test` suite passes
- [x] Manual test: post an image story and verify it appears on recipients' devices
- [x] Manual test: post with `--no-replies` and verify reply is disabled
- [x] Manual test: attempt non-image/video attachment and verify rejection