### PR TITLE
Bound SessionStore session cache to prevent unbounded memory growth

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/storage/sessions/SessionStore.java
+++ b/lib/src/main/java/org/asamk/signal/manager/storage/sessions/SessionStore.java
@@ -18,7 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -28,8 +28,15 @@ public class SessionStore implements SignalServiceSessionStore {
 
     private static final String TABLE_SESSION = "session";
     private static final Logger logger = LoggerFactory.getLogger(SessionStore.class);
+    private static final int MAX_CACHE_SIZE = 1000;
 
-    private final Map<Key, SessionRecord> cachedSessions = new HashMap<>();
+    private final Map<Key, SessionRecord> cachedSessions = new LinkedHashMap<>(16, 0.75f, true) {
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<Key, SessionRecord> eldest) {
+            return size() > MAX_CACHE_SIZE;
+        }
+    };
 
     private final Database database;
     private final int accountIdType;


### PR DESCRIPTION
## Summary

- Replace unbounded `HashMap` in `SessionStore.cachedSessions` with an LRU-bounded `LinkedHashMap` (access-order, max 1000 entries)
- Fixes linear memory growth (~47 MB/hour observed) in long-running daemon mode under sustained group message traffic
- Evicted sessions are reloaded from SQLite on next access, preserving correctness

## Problem

`SessionStore.cachedSessions` grows with every unique `(address, deviceId)` pair seen during message processing and entries are never evicted. Two instances exist per account (ACI + PNI). In a daemon handling messages from many large groups, this map grows monotonically — `SessionRecord` objects are substantial (Double Ratchet state) and the accumulated memory is never reclaimed.

## Fix

A `LinkedHashMap` with access-order and `removeEldestEntry` override caps the cache at 1000 entries per instance (~10 MB total for both ACI + PNI). Cache misses fall through to an indexed SQLite lookup (`UNIQUE(account_id_type, address, device_id)`), which is sub-millisecond.

## Test plan

- [x] `./gradlew compileJava` — builds clean
- [x] `./gradlew test` — all tests pass
- [x] Independent code review: thread safety verified across all 5 synchronized access sites; LRU eviction does not break mutation-through-reference patterns in archive methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHzM2XLKQoX9iraEdhoh3h