### PR TITLE
Bound RecipientStore address cache to prevent unbounded memory growth

### DIFF
--- a/lib/src/main/java/org/asamk/signal/manager/storage/recipients/RecipientStore.java
+++ b/lib/src/main/java/org/asamk/signal/manager/storage/recipients/RecipientStore.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -51,7 +52,16 @@ public class RecipientStore implements RecipientIdCreator, RecipientResolver, Re
 
     private final Map<Long, Long> recipientsMerged = new HashMap<>();
 
-    private final Map<ServiceId, RecipientWithAddress> recipientAddressCache = Collections.synchronizedMap(new HashMap<>());
+    private static final int MAX_RECIPIENT_CACHE_SIZE = 2000;
+
+    private final Map<ServiceId, RecipientWithAddress> recipientAddressCache = Collections.synchronizedMap(
+            new LinkedHashMap<>(16, 0.75f, true) {
+
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<ServiceId, RecipientWithAddress> eldest) {
+                    return size() > MAX_RECIPIENT_CACHE_SIZE;
+                }
+            });
 
     public static void createSql(Connection connection) throws SQLException {
         // When modifying the CREATE statement here, also add a migration in AccountDatabase.java


### PR DESCRIPTION
## Summary

- Replace unbounded `HashMap` in `RecipientStore.recipientAddressCache` with an LRU-bounded `LinkedHashMap` (access-order, max 2000 entries)
- Prevents monotonic memory growth in long-running daemon mode
- Evicted entries are reloaded from SQLite on next access, preserving correctness

## Problem

`recipientAddressCache` (`Collections.synchronizedMap(new HashMap<>())`) grows with every unique `ServiceId` resolved via `findByServiceId()`, which is called on every incoming message. Entries are only removed during rare recipient merge/delete operations. In a long-running daemon handling messages from many contacts and groups, this map grows without bound.

## Fix

Replace the inner `HashMap` with an LRU-bounded `LinkedHashMap` (access-order, max 2000 entries ≈ 600-800 KB). The `Collections.synchronizedMap` wrapper is preserved, which properly protects access-order `get()` mutations and `removeEldestEntry` eviction during `put()`. Cache misses fall through to an indexed SQLite lookup.

## Test plan

- [x] `./gradlew compileJava` — builds clean
- [x] `./gradlew test` — all tests pass
- [x] Independent code review: thread safety verified for all 7 access sites through the synchronized wrapper; confirmed cache is purely read-through (eviction cannot cause data loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHzM2XLKQoX9iraEdhoh3h